### PR TITLE
Adopt CI/packaging codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,6 @@ pynvjitlink/            @rapidsai/numba-cuda-write
 **/CMakeLists.txt  @rapidsai/numba-cuda-write
 **/cmake/          @rapidsai/numba-cuda-write
 
-#build/ops code owners
 #CI code owners
 /.github/                @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,14 @@ pynvjitlink/            @rapidsai/numba-cuda-write
 **/cmake/          @rapidsai/numba-cuda-write
 
 #build/ops code owners
-.github/           @rapidsai/ops-codeowners
+#CI code owners
+/.github/                @rapidsai/ci-codeowners
+/ci/                     @rapidsai/ci-codeowners
+/.pre-commit-config.yaml @rapidsai/ci-codeowners
+
+#packaging code owners
+/.devcontainer/    @rapidsai/packaging-codeowners
+/conda/            @rapidsai/packaging-codeowners
+/dependencies.yaml @rapidsai/packaging-codeowners
+/build.sh          @rapidsai/packaging-codeowners
+pyproject.toml     @rapidsai/packaging-codeowners


### PR DESCRIPTION
This PR overhauls how `ops-codeowners` reviews are handled.

`ops-codeowners` is replaced by `ci-codeowners` & `packaging-codeowners`. The coverage of files is expanded as well.

Additionally, the process will change: reviews will be assigned to a member of the teams instead of a manual request to `ops-codeowners`.
