### PR TITLE
Copy CUDA target docs from Numba 0.60.0 and add basic NVIDIA theme setup

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,6 +52,7 @@ jobs:
     with:
       build_type: pull-request
       script: "ci/test_conda.sh"
+      run_codecov: false
       matrix_filter: ${{ needs.compute-matrix.outputs.TEST_MATRIX }}
   build-wheels:
     needs:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -25,6 +25,10 @@ if errorlevel 9009 (
 
 if "%1" == "" goto help
 
+if "%SPHINXOPTS%" == "" (
+	set SPHINXOPTS=-W
+)
+
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 goto end
 

--- a/docs/source/_static/numba-green-icon-rgb.svg
+++ b/docs/source/_static/numba-green-icon-rgb.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 20.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#76B900;}
+	.st1{fill:none;}
+	.st2{fill:url(#SVGID_1_);}
+</style>
+<g>
+	<path class="st0" d="M333.2,310.3c0,0,136.3-100.5,81.1-165.5c-64-75.4-243.4,84.5-263,52S310.5,86.4,329.9,73.4
+		c2.1-1.4,2.7-4.1,2.1-7.2l20.7-2.4l-12.9-6.5l3.3-12.9l-15,11.7c-5.6-10.1-15.2-21-20.7-24.8c-19.5-12.9-55.2-9.8-107.1,16.2
+		S28,154.6,89.6,245.5c55.2,81.1,213.8-58.3,240.3-35.8c22.7,19.5-152.5,139.6-152.5,139.6s74.4,0,74.7,0
+		C239.2,381.8,177.4,476,177.4,476l224.8-162.4C378.6,310.1,333.2,310.3,333.2,310.3z M272.1,41c8-0.6,14.9,5.6,15.5,13.5
+		c0.6,8-5.6,14.9-13.5,15.5c-8,0.6-14.9-5.6-15.5-13.5C257.9,48.5,264.1,41.6,272.1,41z"/>
+</g>
+<rect x="22.5" y="22.5" class="st1" width="455" height="455"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="301.6" y1="435.7" x2="301.6" y2="435.7" gradientTransform="matrix(1 0 0 -1 0 500)">
+	<stop  offset="0" style="stop-color:#243746"/>
+	<stop  offset="9.525055e-02" style="stop-color:#223442"/>
+	<stop  offset="0.1897" style="stop-color:#1C2B36"/>
+	<stop  offset="0.2839" style="stop-color:#121B22"/>
+	<stop  offset="0.3773" style="stop-color:#030507"/>
+	<stop  offset="0.3961" style="stop-color:#000000"/>
+</linearGradient>
+<path class="st2" d="M301.6,64.3"/>
+</svg>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ author = 'NVIDIA Corporation'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['numpydoc', 'sphinx.ext.intersphinx']
+extensions = ['numpydoc', 'sphinx.ext.intersphinx', 'sphinx.ext.autodoc']
 
 templates_path = ['_templates']
 exclude_patterns = []
@@ -27,6 +27,8 @@ intersphinx_mapping = {
 
 # To prevent autosummary warnings
 numpydoc_show_class_members = False
+
+autodoc_typehints = 'none'
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,27 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Numba CUDA'
+copyright = '2024, NVIDIA'
+author = 'NVIDIA'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,21 +7,36 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Numba CUDA'
-copyright = '2024, NVIDIA'
-author = 'NVIDIA'
+copyright = '2012-2024 Anaconda Inc. 2024, NVIDIA Corporation.'
+author = 'NVIDIA Corporation'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = ['numpydoc', 'sphinx.ext.intersphinx']
 
 templates_path = ['_templates']
 exclude_patterns = []
 
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'llvmlite': ('https://llvmlite.readthedocs.io/en/latest/', None),
+    'numba': ('https://numba.readthedocs.io/en/latest/', None),
+}
 
+# To prevent autosummary warnings
+numpydoc_show_class_members = False
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
+try:
+    import nvidia_sphinx_theme  # noqa: F401
+    html_theme = "nvidia_sphinx_theme"
+except ImportError:
+    html_theme = "sphinx_rtd_theme"
+
 html_static_path = ['_static']
+html_favicon = "_static/numba-green-icon-rgb.svg"
+html_show_sphinx = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. Numba CUDA documentation master file, created by
+   sphinx-quickstart on Wed Jun 12 13:41:17 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Numba CUDA's documentation!
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,12 @@
 Numba CUDA
 ==========
 
+This is the documentation for Numba's CUDA target.
+
+This is presently a work-in-progress - the user guide and reference
+documentation are presently direct copies of the `upstream Numba CUDA
+documentation <https://numba.readthedocs.io/en/0.60.0/>`_.
+
 .. toctree::
    :maxdepth: 2
    :hidden:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,18 +3,12 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Numba CUDA's documentation!
-======================================
+Numba CUDA
+==========
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :hidden:
 
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   user/index.rst
+   reference/index.rst

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -1,0 +1,123 @@
+.. _numba-envvars-gpu-support:
+
+Environment Variables
+---------------------
+
+Various environment variables can be set to affect the behavior of the CUDA
+target.
+
+.. envvar:: NUMBA_DISABLE_CUDA
+
+   If set to non-zero, disable CUDA support.
+
+.. envvar:: NUMBA_FORCE_CUDA_CC
+
+   If set, force the CUDA compute capability to the given version (a
+   string of the type ``major.minor``), regardless of attached devices.
+
+.. envvar:: NUMBA_CUDA_DEFAULT_PTX_CC
+
+   The default compute capability (a string of the type ``major.minor``) to
+   target when compiling to PTX using ``cuda.compile_ptx``. The default is
+   5.0, which is the lowest non-deprecated compute capability in the most
+   recent version of the CUDA toolkit supported (12.4 at present).
+
+.. envvar:: NUMBA_ENABLE_CUDASIM
+
+   If set, don't compile and execute code for the GPU, but use the CUDA
+   Simulator instead. For debugging purposes.
+
+
+.. envvar:: NUMBA_CUDA_ARRAY_INTERFACE_SYNC
+
+   Whether to synchronize on streams provided by objects imported using the CUDA
+   Array Interface. This defaults to 1. If set to 0, then no synchronization
+   takes place, and the user of Numba (and other CUDA libraries) is responsible
+   for ensuring correctness with respect to synchronization on streams.
+
+.. envvar:: NUMBA_CUDA_LOG_LEVEL
+
+   For debugging purposes. If no other logging is configured, the value of this
+   variable is the logging level for CUDA API calls. The default value is
+   ``CRITICAL`` - to trace all API calls on standard error, set this to
+   ``DEBUG``.
+
+.. envvar:: NUMBA_CUDA_LOG_API_ARGS
+
+   By default the CUDA API call logs only give the names of functions called.
+   Setting this variable to 1 also includes the values of arguments to Driver
+   API calls in the logs.
+
+.. envvar:: NUMBA_CUDA_DRIVER
+
+   Path of the directory in which the CUDA driver libraries are to be found.
+   Normally this should not need to be set as Numba can locate the driver in
+   standard locations. However, this variable can be used if the driver is in a
+   non-standard location.
+
+.. envvar:: NUMBA_CUDA_LOG_SIZE
+
+   Buffer size for logs produced by CUDA driver API operations. This defaults
+   to 1024 and should not normally need to be modified - however, if an error
+   in an API call produces a large amount of output that appears to be
+   truncated (perhaps due to multiple long function names, for example) then
+   this variable can be used to increase the buffer size and view the full
+   error message.
+
+.. envvar:: NUMBA_CUDA_VERBOSE_JIT_LOG
+
+   Whether the CUDA driver should produce verbose log messages. Defaults to 1,
+   indicating that verbose messaging is enabled. This should not need to be
+   modified under normal circumstances.
+
+.. envvar:: NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM
+
+   When set to 1, the default stream is the per-thread default stream. When set
+   to 0, the default stream is the legacy default stream. This defaults to 0,
+   for the legacy default stream. See `Stream Synchronization Behavior
+   <https://docs.nvidia.com/cuda/cuda-runtime-api/stream-sync-behavior.html>`_
+   for an explanation of the legacy and per-thread default streams.
+
+   This variable only takes effect when using Numba's internal CUDA bindings;
+   when using the NVIDIA bindings, use the environment variable
+   ``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` instead.
+
+   .. seealso::
+
+      The `Default Stream section
+      <https://nvidia.github.io/cuda-python/release/11.6.0-notes.html#default-stream>`_
+      in the NVIDIA Bindings documentation.
+
+.. envvar:: NUMBA_CUDA_LOW_OCCUPANCY_WARNINGS
+
+   Enable warnings if the grid size is too small relative to the number of
+   streaming multiprocessors (SM). This option is on by default (default value is 1).
+
+   The heuristic checked is whether ``gridsize < 2 * (number of SMs)``. NOTE: The absence of
+   a warning does not imply a good gridsize relative to the number of SMs. Disabling
+   this warning will reduce the number of CUDA API calls (during JIT compilation), as the
+   heuristic needs to check the number of SMs available on the device in the
+   current context.
+
+.. envvar:: NUMBA_CUDA_WARN_ON_IMPLICIT_COPY
+
+   Enable warnings if a kernel is launched with host memory which forces a copy to and
+   from the device. This option is on by default (default value is 1).
+
+.. envvar:: NUMBA_CUDA_USE_NVIDIA_BINDING
+
+   When set to 1, Numba will attempt to use the `NVIDIA CUDA Python binding
+   <https://nvidia.github.io/cuda-python/>`_ to make calls to the driver API
+   instead of using its own ctypes binding. This defaults to 0 (off), as the
+   NVIDIA binding is currently missing support for Per-Thread Default
+   Streams and the profiler APIs.
+
+.. envvar:: NUMBA_CUDA_INCLUDE_PATH
+
+   The location of the CUDA include files. This is used when linking CUDA C/C++
+   sources to Python kernels, and needs to be correctly set for CUDA includes to
+   be available to linked C/C++ sources. On Linux, it defaults to
+   ``/usr/local/cuda/include``. On Windows, the default is
+   ``$env:CUDA_PATH\include``.
+
+

--- a/docs/source/reference/host.rst
+++ b/docs/source/reference/host.rst
@@ -1,0 +1,248 @@
+CUDA Host API
+=============
+
+Device Management
+-----------------
+
+Device detection and enquiry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following functions are available for querying the available hardware:
+
+.. autofunction:: numba.cuda.is_available
+
+.. autofunction:: numba.cuda.detect
+
+Context management
+~~~~~~~~~~~~~~~~~~
+
+CUDA Python functions execute within a CUDA context. Each CUDA device in a
+system has an associated CUDA context, and Numba presently allows only one context
+per thread. For further details on CUDA Contexts, refer to the `CUDA Driver API
+Documentation on Context Management
+<http://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__CTX.html>`_ and the
+`CUDA C Programming Guide Context Documentation
+<http://docs.nvidia.com/cuda/cuda-c-programming-guide/#context>`_. CUDA Contexts
+are instances of the :class:`~numba.cuda.cudadrv.driver.Context` class:
+
+.. autoclass:: numba.cuda.cudadrv.driver.Context
+   :members: reset, get_memory_info, push, pop
+
+The following functions can be used to get or select the context:
+
+.. autofunction:: numba.cuda.current_context
+.. autofunction:: numba.cuda.require_context
+
+The following functions affect the current context:
+
+.. autofunction:: numba.cuda.synchronize
+.. autofunction:: numba.cuda.close
+
+Device management
+~~~~~~~~~~~~~~~~~
+
+Numba maintains a list of supported CUDA-capable devices:
+
+.. attribute:: numba.cuda.gpus
+
+   An indexable list of supported CUDA devices. This list is indexed by integer
+   device ID.
+
+Alternatively, the current device can be obtained:
+
+.. attribute:: numba.cuda.gpus.current
+
+   The currently-selected device.
+
+Getting a device through :attr:`numba.cuda.gpus` always provides an instance of
+:class:`numba.cuda.cudadrv.devices._DeviceContextManager`, which acts as a
+context manager for the selected device:
+
+.. autoclass:: numba.cuda.cudadrv.devices._DeviceContextManager
+
+One may also select a context and device or get the current device using the
+following three functions:
+
+.. autofunction:: numba.cuda.select_device
+.. autofunction:: numba.cuda.get_current_device
+.. autofunction:: numba.cuda.list_devices
+
+The :class:`numba.cuda.cudadrv.driver.Device` class can be used to enquire about
+the functionality of the selected device:
+
+.. class:: numba.cuda.cudadrv.driver.Device
+
+   The device associated with a particular context.
+
+   .. attribute:: compute_capability
+
+      A tuple, *(major, minor)* indicating the supported compute capability.
+
+   .. attribute:: id
+
+      The integer ID of the device.
+
+   .. attribute:: name
+
+      The name of the device (e.g. "GeForce GTX 970").
+
+   .. attribute:: uuid
+
+      The UUID of the device (e.g. "GPU-e6489c45-5b68-3b03-bab7-0e7c8e809643").
+
+   .. method:: reset
+
+      Delete the context for the device. This will destroy all memory
+      allocations, events, and streams created within the context.
+
+   .. attribute:: supports_float16
+
+      Return ``True`` if the device supports float16 operations, ``False``
+      otherwise.
+
+
+Compilation
+-----------
+
+Numba provides an entry point for compiling a Python function without invoking
+any of the driver API. This can be useful for:
+
+- Generating PTX that is to be inlined into other PTX code (e.g. from outside
+  the Numba / Python ecosystem).
+- Generating PTX or LTO-IR to link with objects from non-Python translation
+  units.
+- Generating code when there is no device present.
+- Generating code prior to a fork without initializing CUDA.
+
+.. note:: It is the user's responsibility to manage any ABI issues arising from
+   the use of compilation to PTX / LTO-IR. Passing the ``abi="c"`` keyword
+   argument can provide a solution to most issues that may arise - see
+   :ref:`cuda-using-the-c-abi`.
+
+.. autofunction:: numba.cuda.compile
+
+
+The environment variable ``NUMBA_CUDA_DEFAULT_PTX_CC`` can be set to control
+the default compute capability targeted by ``compile`` - see
+:ref:`numba-envvars-gpu-support`. If code for the compute capability of the
+current device is required, the ``compile_for_current_device`` function can
+be used:
+
+.. autofunction:: numba.cuda.compile_for_current_device
+
+
+Numba also provides two functions that may be used in legacy code that
+specifically compile to PTX only:
+
+.. autofunction:: numba.cuda.compile_ptx
+
+.. autofunction:: numba.cuda.compile_ptx_for_current_device
+
+
+Measurement
+-----------
+
+.. _cuda-profiling:
+
+Profiling
+~~~~~~~~~
+
+The NVidia Visual Profiler can be used directly on executing CUDA Python code -
+it is not a requirement to insert calls to these functions into user code.
+However, these functions can be used to allow profiling to be performed
+selectively on specific portions of the code. For further information on
+profiling, see the `NVidia Profiler User's Guide
+<https://docs.nvidia.com/cuda/profiler-users-guide/>`_.
+
+.. autofunction:: numba.cuda.profile_start
+.. autofunction:: numba.cuda.profile_stop
+.. autofunction:: numba.cuda.profiling
+
+
+.. _events:
+
+Events
+~~~~~~
+
+Events can be used to monitor the progress of execution and to record the
+timestamps of specific points being reached. Event creation returns immediately,
+and the created event can be queried to determine if it has been reached. For
+further information, see the `CUDA C Programming Guide Events section
+<http://docs.nvidia.com/cuda/cuda-c-programming-guide/#events>`_.
+
+The following functions are used for creating and measuring the time between
+events:
+
+.. autofunction:: numba.cuda.event
+.. autofunction:: numba.cuda.event_elapsed_time
+
+Events are instances of the :class:`numba.cuda.cudadrv.driver.Event` class:
+
+.. autoclass:: numba.cuda.cudadrv.driver.Event
+   :members: query, record, synchronize, wait
+
+
+.. _streams:
+
+Stream Management
+-----------------
+
+Streams allow concurrency of execution on a single device within a given
+context. Queued work items in the same stream execute sequentially, but work
+items in different streams may execute concurrently. Most operations involving a
+CUDA device can be performed asynchronously using streams, including data
+transfers and kernel execution. For further details on streams, see the `CUDA C
+Programming Guide Streams section
+<http://docs.nvidia.com/cuda/cuda-c-programming-guide/#streams>`_.
+
+Numba defaults to using the legacy default stream as the default stream. The
+per-thread default stream can be made the default stream by setting the
+environment variable ``NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM`` to ``1`` (see the
+:ref:`CUDA Environment Variables section <numba-envvars-gpu-support>`).
+Regardless of this setting, the objects representing the legacy and per-thread
+default streams can be constructed using the functions below.
+
+Streams are instances of :class:`numba.cuda.cudadrv.driver.Stream`:
+
+.. autoclass:: numba.cuda.cudadrv.driver.Stream
+   :members: synchronize, auto_synchronize, add_callback, async_done
+
+To create a new stream:
+
+.. autofunction:: numba.cuda.stream
+
+To get the default stream:
+
+.. autofunction:: numba.cuda.default_stream
+
+To get the default stream with an explicit choice of whether it is the legacy
+or per-thread default stream:
+
+.. autofunction:: numba.cuda.legacy_default_stream
+
+.. autofunction:: numba.cuda.per_thread_default_stream
+
+To construct a Numba ``Stream`` object using a stream allocated elsewhere, the
+``external_stream`` function is provided. Note that the lifetime of external
+streams must be managed by the user - Numba will not deallocate an external
+stream, and the stream must remain valid whilst the Numba ``Stream`` object is
+in use.
+
+.. autofunction:: numba.cuda.external_stream
+
+
+Runtime
+-------
+
+Numba generally uses the Driver API, but it provides a simple wrapper to the
+Runtime API so that the version of the runtime in use can be queried. This is
+accessed through ``cuda.runtime``, which is an instance of the
+:class:`numba.cuda.cudadrv.runtime.Runtime` class:
+
+.. autoclass:: numba.cuda.cudadrv.runtime.Runtime
+   :members: get_version, is_supported_version, supported_versions
+
+Whether the current runtime is officially supported and tested with the current
+version of Numba can also be queried:
+
+.. autofunction:: numba.cuda.is_supported_version

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,0 +1,10 @@
+CUDA Python Reference
+=====================
+
+.. toctree::
+
+   host.rst
+   kernel.rst
+   types.rst
+   memory.rst
+   libdevice.rst

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -8,3 +8,4 @@ Reference documentation
    types.rst
    memory.rst
    libdevice.rst
+   envvars.rst

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,5 +1,5 @@
-CUDA Python Reference
-=====================
+Reference documentation
+=======================
 
 .. toctree::
 

--- a/docs/source/reference/kernel.rst
+++ b/docs/source/reference/kernel.rst
@@ -1,0 +1,710 @@
+CUDA Kernel API
+===============
+
+Kernel declaration
+------------------
+
+The ``@cuda.jit`` decorator is used to create a CUDA dispatcher object that can
+be configured and launched:
+
+.. autofunction:: numba.cuda.jit
+
+
+Dispatcher objects
+------------------
+
+The usual syntax for configuring a Dispatcher with a launch configuration uses
+subscripting, with the arguments being as in the following:
+
+.. code-block:: python
+
+   # func is some function decorated with @cuda.jit
+   func[griddim, blockdim, stream, sharedmem]
+
+
+The ``griddim`` and ``blockdim`` arguments specify the size of the grid and
+thread blocks, and may be either integers or tuples of length up to 3. The
+``stream`` parameter is an optional stream on which the kernel will be launched,
+and the ``sharedmem`` parameter specifies the size of dynamic shared memory in
+bytes.
+
+Subscripting the Dispatcher returns a configuration object that can be called
+with the kernel arguments:
+
+.. code-block:: python
+
+   configured = func[griddim, blockdim, stream, sharedmem]
+   configured(x, y, z)
+
+
+However, it is more idiomatic to configure and call the kernel within a single
+statement:
+
+.. code-block:: python
+
+   func[griddim, blockdim, stream, sharedmem](x, y, z)
+
+This is similar to launch configuration in CUDA C/C++:
+
+.. code-block:: cuda
+
+   func<<<griddim, blockdim, sharedmem, stream>>>(x, y, z)
+
+.. note:: The order of ``stream`` and ``sharedmem`` are reversed in Numba
+   compared to in CUDA C/C++.
+
+Dispatcher objects also provide several utility methods for inspection and
+creating a specialized instance:
+
+.. autoclass:: numba.cuda.dispatcher.CUDADispatcher
+   :members: inspect_asm, inspect_llvm, inspect_sass, inspect_types,
+             get_regs_per_thread, specialize, specialized, extensions, forall,
+             get_shared_mem_per_block, get_max_threads_per_block,
+             get_const_mem_size, get_local_mem_per_thread
+
+
+
+Intrinsic Attributes and Functions
+----------------------------------
+
+The remainder of the attributes and functions in this section may only be called
+from within a CUDA Kernel.
+
+Thread Indexing
+~~~~~~~~~~~~~~~
+
+.. attribute:: numba.cuda.threadIdx
+
+    The thread indices in the current thread block, accessed through the
+    attributes ``x``, ``y``, and ``z``. Each index is an integer spanning the
+    range from 0 inclusive to the corresponding value of the attribute in
+    :attr:`numba.cuda.blockDim` exclusive.
+
+.. attribute:: numba.cuda.blockIdx
+
+    The block indices in the grid of thread blocks, accessed through the
+    attributes ``x``, ``y``, and ``z``. Each index is an integer spanning the
+    range from 0 inclusive to the corresponding value of the attribute in
+    :attr:`numba.cuda.gridDim` exclusive.
+
+.. attribute:: numba.cuda.blockDim
+
+    The shape of a block of threads, as declared when instantiating the
+    kernel.  This value is the same for all threads in a given kernel, even
+    if they belong to different blocks (i.e. each block is "full").
+
+.. attribute:: numba.cuda.gridDim
+
+    The shape of the grid of blocks, accessed through the attributes ``x``,
+    ``y``, and ``z``.
+
+.. attribute:: numba.cuda.laneid
+
+    The thread index in the current warp, as an integer spanning the range
+    from 0 inclusive to the :attr:`numba.cuda.warpsize` exclusive.
+
+.. attribute:: numba.cuda.warpsize
+
+    The size in threads of a warp on the GPU. Currently this is always 32.
+
+.. function:: numba.cuda.grid(ndim)
+
+   Return the absolute position of the current thread in the entire
+   grid of blocks.  *ndim* should correspond to the number of dimensions
+   declared when instantiating the kernel.  If *ndim* is 1, a single integer
+   is returned.  If *ndim* is 2 or 3, a tuple of the given number of
+   integers is returned.
+
+   Computation of the first integer is as follows::
+
+      cuda.threadIdx.x + cuda.blockIdx.x * cuda.blockDim.x
+
+   and is similar for the other two indices, but using the ``y`` and ``z``
+   attributes.
+
+.. function:: numba.cuda.gridsize(ndim)
+
+   Return the absolute size (or shape) in threads of the entire grid of
+   blocks. *ndim* should correspond to the number of dimensions declared when
+   instantiating the kernel.
+
+   Computation of the first integer is as follows::
+
+       cuda.blockDim.x * cuda.gridDim.x
+
+   and is similar for the other two indices, but using the ``y`` and ``z``
+   attributes.
+
+Memory Management
+~~~~~~~~~~~~~~~~~
+
+.. function:: numba.cuda.shared.array(shape, dtype)
+
+   Creates an array in the local memory space of the CUDA kernel with
+   the given ``shape`` and ``dtype``.
+
+   Returns an array with its content uninitialized.
+
+   .. note:: All threads in the same thread block sees the same array.
+
+.. function:: numba.cuda.local.array(shape, dtype)
+
+   Creates an array in the local memory space of the CUDA kernel with the
+   given ``shape`` and ``dtype``.
+
+   Returns an array with its content uninitialized.
+
+   .. note:: Each thread sees a unique array.
+
+.. function:: numba.cuda.const.array_like(ary)
+
+   Copies the ``ary`` into constant memory space on the CUDA kernel at compile
+   time.
+
+   Returns an array like the ``ary`` argument.
+
+   .. note:: All threads and blocks see the same array.
+
+Synchronization and Atomic Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. function:: numba.cuda.atomic.add(array, idx, value)
+
+    Perform ``array[idx] += value``. Support int32, int64, float32 and
+    float64 only. The ``idx`` argument can be an integer or a tuple of integer
+    indices for indexing into multiple dimensional arrays. The number of element
+    in ``idx`` must match the number of dimension of ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.sub(array, idx, value)
+
+    Perform ``array[idx] -= value``. Supports int32, int64, float32 and
+    float64 only. The ``idx`` argument can be an integer or a tuple of integer
+    indices for indexing into multi-dimensional arrays. The number of elements
+    in ``idx`` must match the number of dimensions of ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.and_(array, idx, value)
+
+    Perform ``array[idx] &= value``. Supports int32, uint32, int64,
+    and uint64 only. The ``idx`` argument can be an integer or a tuple of
+    integer indices for indexing into multi-dimensional arrays. The number
+    of elements in ``idx`` must match the number of dimensions of ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.or_(array, idx, value)
+
+    Perform ``array[idx] |= value``. Supports int32, uint32, int64,
+    and uint64 only. The ``idx`` argument can be an integer or a tuple of
+    integer indices for indexing into multi-dimensional arrays. The number
+    of elements in ``idx`` must match the number of dimensions of ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.xor(array, idx, value)
+
+    Perform ``array[idx] ^= value``. Supports int32, uint32, int64,
+    and uint64 only. The ``idx`` argument can be an integer or a tuple of
+    integer indices for indexing into multi-dimensional arrays. The number
+    of elements in ``idx`` must match the number of dimensions of ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.exch(array, idx, value)
+
+    Perform ``array[idx] = value``. Supports int32, uint32, int64,
+    and uint64 only. The ``idx`` argument can be an integer or a tuple of
+    integer indices for indexing into multi-dimensional arrays. The number
+    of elements in ``idx`` must match the number of dimensions of ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.inc(array, idx, value)
+
+    Perform ``array[idx] = (0 if array[idx] >= value else array[idx] + 1)``.
+    Supports uint32, and uint64 only. The ``idx`` argument can be an integer
+    or a tuple of integer indices for indexing into multi-dimensional arrays.
+    The number of elements in ``idx`` must match the number of dimensions of
+    ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.dec(array, idx, value)
+
+    Perform ``array[idx] =
+    (value if (array[idx] == 0) or (array[idx] > value) else array[idx] - 1)``.
+    Supports uint32, and uint64 only. The ``idx`` argument can be an integer
+    or a tuple of integer indices for indexing into multi-dimensional arrays.
+    The number of elements in ``idx`` must match the number of dimensions of
+    ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.max(array, idx, value)
+
+    Perform ``array[idx] = max(array[idx], value)``. Support int32, int64,
+    float32 and float64 only. The ``idx`` argument can be an integer or a
+    tuple of integer indices for indexing into multiple dimensional arrays.
+    The number of element in ``idx`` must match the number of dimension of
+    ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic load.
+
+.. function:: numba.cuda.atomic.cas(array, idx, old, value)
+
+    Perform ``if array[idx] == old: array[idx] = value``. Supports int32,
+    int64, uint32, uint64 indexes only. The ``idx`` argument can be an integer
+    or a tuple of integer indices for indexing into multi-dimensional arrays.
+    The number of elements in ``idx`` must match the number of dimensions of
+    ``array``.
+
+    Returns the value of ``array[idx]`` before storing the new value.
+    Behaves like an atomic compare and swap.
+
+
+.. function:: numba.cuda.syncthreads
+
+    Synchronize all threads in the same thread block.  This function implements
+    the same pattern as barriers in traditional multi-threaded programming: this
+    function waits until all threads in the block call it, at which point it
+    returns control to all its callers.
+
+.. function:: numba.cuda.syncthreads_count(predicate)
+
+    An extension to :attr:`numba.cuda.syncthreads` where the return value is a count
+    of the threads where ``predicate`` is true.
+
+.. function:: numba.cuda.syncthreads_and(predicate)
+
+    An extension to :attr:`numba.cuda.syncthreads` where 1 is returned if ``predicate`` is
+    true for all threads or 0 otherwise.
+
+.. function:: numba.cuda.syncthreads_or(predicate)
+
+    An extension to :attr:`numba.cuda.syncthreads` where 1 is returned if ``predicate`` is
+    true for any thread or 0 otherwise.
+
+    .. warning:: All syncthreads functions must be called by every thread in the
+                 thread-block. Falling to do so may result in undefined behavior.
+
+
+Cooperative Groups
+~~~~~~~~~~~~~~~~~~
+
+.. function:: numba.cuda.cg.this_grid()
+
+   Get the current grid group.
+
+   :return: The current grid group
+   :rtype: numba.cuda.cg.GridGroup
+
+.. class:: numba.cuda.cg.GridGroup
+
+   A grid group. Users should not construct a GridGroup directly - instead, get
+   the current grid group using :func:`cg.this_grid() <numba.cuda.cg.this_grid>`.
+
+   .. method:: sync()
+
+      Synchronize the current grid group.
+
+
+Memory Fences
+~~~~~~~~~~~~~
+
+The memory fences are used to guarantee the effect of memory operations
+are visible by other threads within the same thread-block, the same GPU device,
+and the same system (across GPUs on global memory). Memory loads and stores
+are guaranteed to not move across the memory fences by optimization passes.
+
+.. warning:: The memory fences are considered to be advanced API and most
+             usercases should use the thread barrier (e.g. ``syncthreads()``).
+
+
+
+.. function:: numba.cuda.threadfence
+
+   A memory fence at device level (within the GPU).
+
+.. function:: numba.cuda.threadfence_block
+
+   A memory fence at thread block level.
+
+.. function:: numba.cuda.threadfence_system
+
+
+   A memory fence at system level (across GPUs).
+
+Warp Intrinsics
+~~~~~~~~~~~~~~~
+
+The argument ``membermask`` is a 32 bit integer mask with each bit
+corresponding to a thread in the warp, with 1 meaning the thread is in the
+subset of threads within the function call. The ``membermask`` must be all 1 if
+the GPU compute capability is below 7.x.
+
+.. function:: numba.cuda.syncwarp(membermask)
+
+   Synchronize a masked subset of the threads in a warp.
+
+.. function:: numba.cuda.all_sync(membermask, predicate)
+
+    If the ``predicate`` is true for all threads in the masked warp, then
+    a non-zero value is returned, otherwise 0 is returned.
+
+.. function:: numba.cuda.any_sync(membermask, predicate)
+
+    If the ``predicate`` is true for any thread in the masked warp, then
+    a non-zero value is returned, otherwise 0 is returned.
+
+.. function:: numba.cuda.eq_sync(membermask, predicate)
+
+    If the boolean ``predicate`` is the same for all threads in the masked warp,
+    then a non-zero value is returned, otherwise 0 is returned.
+
+.. function:: numba.cuda.ballot_sync(membermask, predicate)
+
+    Returns a mask of all threads in the warp whose ``predicate`` is true,
+    and are within the given mask.
+
+.. function:: numba.cuda.shfl_sync(membermask, value, src_lane)
+
+    Shuffles ``value`` across the masked warp and returns the ``value``
+    from ``src_lane``. If this is outside the warp, then the
+    given ``value`` is returned.
+
+.. function:: numba.cuda.shfl_up_sync(membermask, value, delta)
+
+    Shuffles ``value`` across the masked warp and returns the ``value``
+    from ``laneid - delta``. If this is outside the warp, then the
+    given ``value`` is returned.
+
+.. function:: numba.cuda.shfl_down_sync(membermask, value, delta)
+
+    Shuffles ``value`` across the masked warp and returns the ``value``
+    from ``laneid + delta``. If this is outside the warp, then the
+    given ``value`` is returned.
+
+.. function:: numba.cuda.shfl_xor_sync(membermask, value, lane_mask)
+
+    Shuffles ``value`` across the masked warp and returns the ``value``
+    from ``laneid ^ lane_mask``.
+
+.. function:: numba.cuda.match_any_sync(membermask, value, lane_mask)
+
+    Returns a mask of threads that have same ``value`` as the given ``value``
+    from within the masked warp.
+
+.. function:: numba.cuda.match_all_sync(membermask, value, lane_mask)
+
+    Returns a tuple of (mask, pred), where mask is a mask of threads that have
+    same ``value`` as the given ``value`` from within the masked warp, if they
+    all have the same value, otherwise it is 0. And pred is a boolean of whether
+    or not all threads in the mask warp have the same warp.
+
+.. function:: numba.cuda.activemask()
+
+    Returns a 32-bit integer mask of all currently active threads in the
+    calling warp. The Nth bit is set if the Nth lane in the warp is active when
+    activemask() is called. Inactive threads are represented by 0 bits in the
+    returned mask. Threads which have exited the kernel are always marked as
+    inactive.
+
+.. function:: numba.cuda.lanemask_lt()
+
+    Returns a 32-bit integer mask of all lanes (including inactive ones) with
+    ID less than the current lane.
+
+
+Integer Intrinsics
+~~~~~~~~~~~~~~~~~~
+
+A subset of the CUDA Math API's integer intrinsics are available. For further
+documentation, including semantics, please refer to the `CUDA Toolkit
+documentation
+<https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__INTRINSIC__INT.html>`_.
+
+
+.. function:: numba.cuda.popc(x)
+
+   Returns the number of bits set in ``x``.
+
+.. function:: numba.cuda.brev(x)
+
+   Returns the reverse of the bit pattern of ``x``. For example, ``0b10110110``
+   becomes ``0b01101101``.
+
+.. function:: numba.cuda.clz(x)
+
+   Returns the number of leading zeros in ``x``.
+
+.. function:: numba.cuda.ffs(x)
+
+   Returns the position of the first (least significant) bit set to 1 in ``x``,
+   where the least significant bit position is 1. ``ffs(0)`` returns 0.
+
+
+Floating Point Intrinsics
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A subset of the CUDA Math API's floating point intrinsics are available. For further
+documentation, including semantics, please refer to the `single
+<https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html>`_ and
+`double <https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__DOUBLE.html>`_
+precision parts of the CUDA Toolkit documentation.
+
+
+.. function:: numba.cuda.fma
+
+   Perform the fused multiply-add operation. Named after the ``fma`` and ``fmaf`` in
+   the C api, but maps to the ``fma.rn.f32`` and ``fma.rn.f64`` (round-to-nearest-even)
+   PTX instructions.
+
+.. function:: numba.cuda.cbrt (x)
+
+   Perform the cube root operation, x ** (1/3). Named after the functions
+   ``cbrt`` and ``cbrtf`` in the C api. Supports float32, and float64 arguments
+   only.
+
+16-bit Floating Point Intrinsics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The functions in the ``cuda.fp16`` module are used to operate on 16-bit
+floating point operands. These functions return a 16-bit floating point result.
+
+To determine whether Numba supports compiling code that uses the ``float16``
+type in the current configuration, use:
+
+   .. function:: numba.cuda.is_float16_supported ()
+
+   Return ``True`` if 16-bit floats are supported, ``False`` otherwise.
+
+To check whether a device supports ``float16``, use its
+:attr:`supports_float16 <numba.cuda.cudadrv.driver.Device.supports_float16>`
+attribute.
+
+.. function:: numba.cuda.fp16.hfma (a, b, c)
+
+   Perform the fused multiply-add operation ``(a * b) + c`` on 16-bit
+   floating point arguments in round to nearest mode. Maps to the ``fma.rn.f16``
+   PTX instruction.
+
+   Returns the 16-bit floating point result of the fused multiply-add.
+
+.. function:: numba.cuda.fp16.hadd (a, b)
+
+   Perform the add operation ``a + b`` on 16-bit floating point arguments in
+   round to nearest mode. Maps to the ``add.f16`` PTX instruction.
+
+   Returns the 16-bit floating point result of the addition.
+
+.. function:: numba.cuda.fp16.hsub (a, b)
+
+   Perform the subtract operation ``a - b`` on 16-bit floating point arguments in
+   round to nearest mode. Maps to the ``sub.f16`` PTX instruction.
+
+   Returns the 16-bit floating point result of the subtraction.
+
+.. function:: numba.cuda.fp16.hmul (a, b)
+
+   Perform the multiply operation ``a * b`` on 16-bit floating point arguments in
+   round to nearest mode. Maps to the ``mul.f16`` PTX instruction.
+
+   Returns the 16-bit floating point result of the multiplication.
+
+.. function:: numba.cuda.fp16.hdiv (a, b)
+
+   Perform the divide operation ``a / b`` on 16-bit floating point arguments in
+   round to nearest mode.
+
+   Returns the 16-bit floating point result of the division.
+
+.. function:: numba.cuda.fp16.hneg (a)
+
+   Perform the negation operation ``-a`` on the 16-bit floating point argument.
+   Maps to the ``neg.f16`` PTX instruction.
+
+   Returns the 16-bit floating point result of the negation.
+
+.. function:: numba.cuda.fp16.habs (a)
+
+   Perform the absolute value operation ``|a|`` on the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the absolute value operation.
+
+.. function:: numba.cuda.fp16.hsin (a)
+
+   Calculates the trigonometry sine function of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the sine operation.
+
+.. function:: numba.cuda.fp16.hcos (a)
+
+   Calculates the trigonometry cosine function of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the cosine operation.
+
+.. function:: numba.cuda.fp16.hlog (a)
+
+   Calculates the natural logarithm of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the natural log operation.
+
+.. function:: numba.cuda.fp16.hlog10 (a)
+
+   Calculates the base 10 logarithm of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the log base 10 operation.
+
+.. function:: numba.cuda.fp16.hlog2 (a)
+
+   Calculates the base 2 logarithm on the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the log base 2 operation.
+
+.. function:: numba.cuda.fp16.hexp (a)
+
+   Calculates the natural exponential operation of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the exponential operation.
+
+.. function:: numba.cuda.fp16.hexp10 (a)
+
+   Calculates the base 10 exponential of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the exponential operation.
+
+.. function:: numba.cuda.fp16.hexp2 (a)
+
+   Calculates the base 2 exponential of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the exponential operation.
+
+.. function:: numba.cuda.fp16.hfloor (a)
+
+   Calculates the floor operation, the largest integer less than or equal to ``a``,
+   on the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the floor operation.
+
+.. function:: numba.cuda.fp16.hceil (a)
+
+   Calculates the ceiling operation, the smallest integer greater than or equal to ``a``,
+   on the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the ceil operation.
+
+.. function:: numba.cuda.fp16.hsqrt (a)
+
+   Calculates the square root operation of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the square root operation.
+
+.. function:: numba.cuda.fp16.hrsqrt (a)
+
+   Calculates the reciprocal of the square root of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the reciprocal square root operation.
+
+.. function:: numba.cuda.fp16.hrcp (a)
+
+   Calculates the reciprocal of the 16-bit floating point argument.
+
+   Returns the 16-bit floating point result of the reciprocal.
+
+.. function:: numba.cuda.fp16.hrint (a)
+
+   Round the input 16-bit floating point argument to nearest integer value.
+
+   Returns the 16-bit floating point result of the rounding.
+
+.. function:: numba.cuda.fp16.htrunc (a)
+
+   Truncate the input 16-bit floating point argument to the nearest integer
+   that does not exceed the input argument in magnitude.
+
+   Returns the 16-bit floating point result of the truncation.
+
+.. function:: numba.cuda.fp16.heq (a, b)
+
+   Perform the comparison operation ``a == b`` on 16-bit floating point arguments.
+
+   Returns a boolean.
+
+.. function:: numba.cuda.fp16.hne (a, b)
+
+   Perform the comparison operation ``a != b`` on 16-bit floating point arguments.
+
+   Returns a boolean.
+
+.. function:: numba.cuda.fp16.hgt (a, b)
+
+   Perform the comparison operation ``a > b`` on 16-bit floating point arguments.
+
+   Returns a boolean.
+
+.. function:: numba.cuda.fp16.hge (a, b)
+
+   Perform the comparison operation ``a >= b`` on 16-bit floating point arguments.
+
+   Returns a boolean.
+
+.. function:: numba.cuda.fp16.hlt (a, b)
+
+   Perform the comparison operation ``a < b`` on 16-bit floating point arguments.
+
+   Returns a boolean.
+
+.. function:: numba.cuda.fp16.hle (a, b)
+
+   Perform the comparison operation ``a <= b`` on 16-bit floating point arguments.
+
+   Returns a boolean.
+
+.. function:: numba.cuda.fp16.hmax (a, b)
+
+   Perform the operation ``a if a > b else b.``
+
+   Returns a 16-bit floating point value.
+
+.. function:: numba.cuda.fp16.hmin (a, b)
+
+   Perform the operation ``a if a < b else b.``
+
+   Returns a 16-bit floating point value.
+
+Control Flow Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A subset of the CUDA's control flow instructions are directly available as
+intrinsics. Avoiding branches is a key way to improve CUDA performance, and
+using these intrinsics mean you don't have to rely on the ``nvcc`` optimizer
+identifying and removing branches. For further documentation, including
+semantics, please refer to the `relevant CUDA Toolkit documentation
+<https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#comparison-and-selection-instructions>`_.
+
+
+.. function:: numba.cuda.selp
+
+    Select between two expressions, depending on the value of the first
+    argument. Similar to LLVM's ``select`` instruction.
+
+
+Timer Intrinsics
+~~~~~~~~~~~~~~~~
+
+.. function:: numba.cuda.nanosleep(ns)
+
+    Suspends the thread for a sleep duration approximately close to the delay
+    ``ns``, specified in nanoseconds.

--- a/docs/source/reference/libdevice.rst
+++ b/docs/source/reference/libdevice.rst
@@ -1,0 +1,16 @@
+Libdevice functions
+===================
+
+All wrapped libdevice functions are listed in this section. All functions in
+libdevice are wrapped, with the exception of ``__nv_nan`` and ``__nv_nanf``.
+These functions return a representation of a quiet NaN, but the argument they
+take (a pointer to an object specifying the representation) is undocumented, and
+follows an unusual form compared to the rest of libdevice - it is not an output
+like every other pointer argument. If a NaN is required, one can be obtained in
+CUDA Python by other means, e.g. ``math.nan``.
+
+Wrapped functions
+-----------------
+
+.. automodule:: numba.cuda.libdevice
+   :members:

--- a/docs/source/reference/memory.rst
+++ b/docs/source/reference/memory.rst
@@ -1,0 +1,24 @@
+Memory Management
+=================
+
+.. autofunction:: numba.cuda.to_device
+.. autofunction:: numba.cuda.device_array
+.. autofunction:: numba.cuda.device_array_like
+.. autofunction:: numba.cuda.pinned_array
+.. autofunction:: numba.cuda.pinned_array_like
+.. autofunction:: numba.cuda.mapped_array
+.. autofunction:: numba.cuda.mapped_array_like
+.. autofunction:: numba.cuda.managed_array
+.. autofunction:: numba.cuda.pinned
+.. autofunction:: numba.cuda.mapped
+
+Device Objects
+--------------
+
+.. autoclass:: numba.cuda.cudadrv.devicearray.DeviceNDArray
+   :members: copy_to_device, copy_to_host, is_c_contiguous, is_f_contiguous,
+              ravel, reshape, split
+.. autoclass:: numba.cuda.cudadrv.devicearray.DeviceRecord
+   :members: copy_to_device, copy_to_host
+.. autoclass:: numba.cuda.cudadrv.devicearray.MappedNDArray
+   :members: copy_to_device, copy_to_host, split

--- a/docs/source/reference/types.rst
+++ b/docs/source/reference/types.rst
@@ -1,0 +1,56 @@
+CUDA-Specific Types
+====================
+
+.. note::
+
+    This page is about types specific to CUDA targets. Many other types are also
+    available in the CUDA target - see :ref:`cuda-built-in-types`.
+
+Vector Types
+~~~~~~~~~~~~
+
+`CUDA Vector Types <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#built-in-vector-types>`_
+are usable in kernels. There are two important distinctions from vector types in CUDA C/C++:
+
+First, the recommended names for vector types in Numba CUDA is formatted as ``<base_type>x<N>``,
+where ``base_type`` is the base type of the vector, and ``N`` is the number of elements in the vector.
+Examples include ``int64x3``, ``uint16x4``, ``float32x4``, etc. For new Numba CUDA kernels,
+this is the recommended way to instantiate vector types.
+
+For convenience, users adapting existing kernels from CUDA C/C++ to Python may use
+aliases consistent with the C/C++ namings. For example, ``float3`` aliases ``float32x3``,
+``long3`` aliases ``int32x3`` or ``int64x3`` (depending on the platform), etc. 
+
+Second, unlike CUDA C/C++ where factory functions are used, vector types are constructed directly
+with their constructor. For example, to construct a ``float32x3``:
+
+.. code-block:: python3
+
+    from numba.cuda import float32x3
+
+    # In kernel
+    f3 = float32x3(0.0, -1.0, 1.0)
+
+Additionally, vector types can be constructed from a combination of vector and
+primitive types, as long as the total number of components matches the result
+vector type. For example, all of the following constructions are valid:
+
+.. code-block:: python3
+
+    zero = uint32(0)
+    u2 = uint32x2(1, 2)
+    # Construct a 3-component vector with primitive type and a 2-component vector
+    u3 = uint32x3(zero, u2)
+    # Construct a 4-component vector with 2 2-component vectors
+    u4 = uint32x4(u2, u2)
+
+The 1st, 2nd, 3rd and 4th component of the vector type can be accessed through fields 
+``x``, ``y``, ``z``, and ``w`` respectively. The components are immutable after
+construction in the present version of Numba; it is expected that support for
+mutating vector components will be added in a future release.
+
+.. code-block:: python3
+
+    v1 = float32x2(1.0, 1.0)
+    v2 = float32x2(1.0, -1.0)
+    dotprod = v1.x * v2.x + v1.y * v2.y

--- a/docs/source/user/bindings.rst
+++ b/docs/source/user/bindings.rst
@@ -1,0 +1,43 @@
+CUDA Bindings
+=============
+
+Numba supports two bindings to the CUDA Driver APIs: its own internal bindings
+based on ctypes, and the official `NVIDIA CUDA Python bindings
+<https://nvidia.github.io/cuda-python/>`_. Functionality is equivalent between
+the two bindings.
+
+The internal bindings are used by default. If the NVIDIA bindings are installed,
+then they can be used by setting the environment variable
+``NUMBA_CUDA_USE_NVIDIA_BINDING`` to ``1`` prior to the import of Numba. Once
+Numba has been imported, the selected binding cannot be changed.
+
+
+Per-Thread Default Streams
+--------------------------
+
+Responsibility for handling Per-Thread Default Streams (PTDS) is delegated to
+the NVIDIA bindings when they are in use. To use PTDS with the NVIDIA bindings,
+set the environment variable ``CUDA_PYTHON_CUDA_PER_THREAD_DEFAULT_STREAM`` to
+``1`` instead of Numba's environmnent variable
+:envvar:`NUMBA_CUDA_PER_THREAD_DEFAULT_STREAM`.
+
+.. seealso::
+
+   The `Default Stream section
+   <https://nvidia.github.io/cuda-python/release/11.6.0-notes.html#default-stream>`_
+   in the NVIDIA Bindings documentation.
+
+
+Roadmap
+-------
+
+In Numba 0.56, the NVIDIA Bindings will be used by default, if they are
+installed.
+
+In future versions of Numba:
+
+- The internal bindings will be deprecated.
+- The internal bindings will be removed.
+
+At present, no specific release is planned for the deprecation or removal of
+the internal bindings.

--- a/docs/source/user/caching.rst
+++ b/docs/source/user/caching.rst
@@ -1,0 +1,35 @@
+On-disk Kernel Caching
+======================
+
+When the ``cache`` keyword argument of the :func:`@cuda.jit <numba.cuda.jit>`
+decorator is ``True``, a file-based cache is enabled. This shortens compilation
+times when the function was already compiled in a previous invocation.
+
+The cache is maintained in the ``__pycache__`` subdirectory of the directory
+containing the source file; if the current user is not allowed to write to it,
+the cache implementation falls back to a platform-specific user-wide cache
+directory (such as ``$HOME/.cache/numba`` on Unix platforms).
+
+
+Compute capability considerations
+---------------------------------
+
+Separate cache files are maintained for each compute capability. When a cached
+kernel is loaded, the compute capability of the device the kernel is first
+launched on in the current run is used to determine which version to load.
+Therefore, on systems that have multiple GPUs with differing compute
+capabilities, the cached versions of kernels are only used for one compute
+capability, and recompilation will occur for other compute capabilities.
+
+For example: if a system has two GPUs, one of compute capability 7.5 and one of
+8.0, then:
+
+* If a cached kernel is first launched on the CC 7.5 device, then the cached
+  version for CC 7.5 is used. If it is subsequently launched on the CC 8.0
+  device, a recompilation will occur.
+* If in a subsequent run the cached kernel is first launched on the CC 8.0
+  device, then the cached version for CC 8.0 is used. A subsequent launch on
+  the CC 7.5 device will require a recompilation.
+
+This limitation is not expected to present issues in most practical scenarios,
+as multi-GPU production systems tend to have identical GPUs within each node.

--- a/docs/source/user/cooperative_groups.rst
+++ b/docs/source/user/cooperative_groups.rst
@@ -1,0 +1,108 @@
+==================
+Cooperative Groups
+==================
+
+Supported features
+------------------
+
+Numba's Cooperative Groups support presently provides grid groups and grid
+synchronization, along with cooperative kernel launches.
+
+Cooperative groups are supported on Linux, and Windows for devices in `TCC
+mode
+<https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#tesla-compute-cluster-mode-for-windows>`_.
+
+
+Using Grid Groups
+-----------------
+
+To get the current grid group, use the :meth:`cg.this_grid()
+<numba.cuda.cg.this_grid>` function:
+
+.. code-block:: python
+
+   g = cuda.cg.this_grid()
+
+Synchronizing the grid is done with the :meth:`sync()
+<numba.cuda.cg.GridGroup.sync>` method of the grid group:
+
+.. code-block:: python
+
+   g.sync()
+
+
+Cooperative Launches
+--------------------
+
+Unlike the CUDA C/C++ API, a cooperative launch is invoked using the same syntax
+as a normal kernel launch - Numba automatically determines whether a cooperative
+launch is required based on whether a grid group is synchronized in the kernel.
+
+The grid size limit for a cooperative launch is more restrictive than for a
+normal launch - the grid must be no larger than the maximum number of active
+blocks on the device on which it is launched. To get maximum grid size for a
+cooperative launch of a kernel with a given block size and dynamic shared
+memory requirement, use the ``max_cooperative_grid_blocks()`` method of kernel
+overloads:
+
+.. automethod:: numba.cuda.dispatcher._Kernel.max_cooperative_grid_blocks
+
+This can be used to ensure that the kernel is launched with no more than the
+maximum number of blocks. Exceeding the maximum number of blocks for the
+cooperative launch will result in a ``CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE``
+error. 
+
+
+Applications and Example
+------------------------
+
+Grid group synchronization can be used to implement a global barrier across all
+threads in the grid - applications of this include a global reduction to a
+single value, or looping over rows of a large matrix sequentially using the
+entire grid to operate on column elements in parallel.
+
+In the following example, rows are written sequentially by the grid. Each thread
+in the grid reads a value from the previous row written by it's *opposite*
+thread. A grid sync is needed to ensure that threads in the grid don't run ahead
+of threads in other blocks, or fail to see updates from their opposite thread.
+
+First we'll define our kernel:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cg.py
+   :language: python
+   :caption: from ``test_grid_sync`` of ``numba/cuda/tests/doc_example/test_cg.py``
+   :start-after: magictoken.ex_grid_sync_kernel.begin
+   :end-before: magictoken.ex_grid_sync_kernel.end
+   :dedent: 8
+   :linenos:
+
+Then create some empty input data and determine the grid and block sizes:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cg.py
+   :language: python
+   :caption: from ``test_grid_sync`` of ``numba/cuda/tests/doc_example/test_cg.py``
+   :start-after: magictoken.ex_grid_sync_data.begin
+   :end-before: magictoken.ex_grid_sync_data.end
+   :dedent: 8
+   :linenos:
+
+Finally we launch the kernel and print the result:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cg.py
+   :language: python
+   :caption: from ``test_grid_sync`` of ``numba/cuda/tests/doc_example/test_cg.py``
+   :start-after: magictoken.ex_grid_sync_launch.begin
+   :end-before: magictoken.ex_grid_sync_launch.end
+   :dedent: 8
+   :linenos:
+
+
+The maximum grid size for ``sequential_rows`` can be enquired using:
+
+
+.. code-block:: python
+
+   overload = sequential_rows.overloads[(int32[:,::1],)
+   max_blocks = overload.max_cooperative_grid_blocks(blockdim)
+   print(max_blocks)
+   # 1152 (e.g. on Quadro RTX 8000 with Numba 0.52.1 and CUDA 11.0)

--- a/docs/source/user/cooperative_groups.rst
+++ b/docs/source/user/cooperative_groups.rst
@@ -68,7 +68,7 @@ of threads in other blocks, or fail to see updates from their opposite thread.
 
 First we'll define our kernel:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cg.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_cg.py
    :language: python
    :caption: from ``test_grid_sync`` of ``numba/cuda/tests/doc_example/test_cg.py``
    :start-after: magictoken.ex_grid_sync_kernel.begin
@@ -78,7 +78,7 @@ First we'll define our kernel:
 
 Then create some empty input data and determine the grid and block sizes:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cg.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_cg.py
    :language: python
    :caption: from ``test_grid_sync`` of ``numba/cuda/tests/doc_example/test_cg.py``
    :start-after: magictoken.ex_grid_sync_data.begin
@@ -88,7 +88,7 @@ Then create some empty input data and determine the grid and block sizes:
 
 Finally we launch the kernel and print the result:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cg.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_cg.py
    :language: python
    :caption: from ``test_grid_sync`` of ``numba/cuda/tests/doc_example/test_cg.py``
    :start-after: magictoken.ex_grid_sync_launch.begin

--- a/docs/source/user/cuda_array_interface.rst
+++ b/docs/source/user/cuda_array_interface.rst
@@ -1,0 +1,531 @@
+.. _cuda-array-interface:
+
+================================
+CUDA Array Interface (Version 3)
+================================
+
+The *CUDA Array Interface* (or CAI) is created for interoperability between
+different implementations of CUDA array-like objects in various projects. The
+idea is borrowed from the `NumPy array interface`_.
+
+
+.. note::
+    Currently, we only define the Python-side interface.  In the future, we may
+    add a C-side interface for efficient exchange of the information in
+    compiled code.
+
+
+Python Interface Specification
+==============================
+
+.. note:: Experimental feature.  Specification may change.
+
+The ``__cuda_array_interface__`` attribute returns a dictionary (``dict``)
+that must contain the following entries:
+
+- **shape**: ``(integer, ...)``
+
+  A tuple of ``int`` (or ``long``) representing the size of each dimension.
+
+- **typestr**: ``str``
+
+  The type string.  This has the same definition as ``typestr`` in the
+  `NumPy array interface`_.
+
+- **data**: ``(integer, boolean)``
+
+  The **data** is a 2-tuple.  The first element is the data pointer
+  as a Python ``int`` (or ``long``).  The data must be device-accessible.
+  For zero-size arrays, use ``0`` here.
+  The second element is the read-only flag as a Python ``bool``.
+
+  Because the user of the interface may or may not be in the same context,
+  the most common case is to use ``cuPointerGetAttribute`` with
+  ``CU_POINTER_ATTRIBUTE_DEVICE_POINTER`` in the CUDA driver API (or the
+  equivalent CUDA Runtime API) to retrieve a device pointer that
+  is usable in the currently active context.
+
+- **version**: ``integer``
+
+  An integer for the version of the interface being exported.
+  The current version is *3*.
+
+
+The following are optional entries:
+
+- **strides**: ``None`` or ``(integer, ...)``
+
+  If **strides** is not given, or it is ``None``, the array is in
+  C-contiguous layout. Otherwise, a tuple of ``int`` (or ``long``) is explicitly
+  given for representing the number of bytes to skip to access the next
+  element at each dimension.
+
+- **descr**
+
+  This is for describing more complicated types.  This follows the same
+  specification as in the `NumPy array interface`_.
+
+- **mask**: ``None`` or object exposing the ``__cuda_array_interface__``
+
+  If ``None`` then all values in **data** are valid. All elements of the mask
+  array should be interpreted only as true or not true indicating which
+  elements of this array are valid. This has the same definition as ``mask``
+  in the `NumPy array interface`_.
+
+  .. note:: Numba does not currently support working with masked CUDA arrays
+            and will raise a ``NotImplementedError`` exception if one is passed
+            to a GPU function.
+
+- **stream**: ``None`` or ``integer``
+
+  An optional stream upon which synchronization must take place at the point of
+  consumption, either by synchronizing on the stream or enqueuing operations on
+  the data on the given stream. Integer values in this entry are as follows:
+
+  - ``0``: This is disallowed as it would be ambiguous between ``None`` and the
+    default stream, and also between the legacy and per-thread default streams.
+    Any use case where ``0`` might be given should either use ``None``, ``1``,
+    or ``2`` instead for clarity.
+  - ``1``: The legacy default stream.
+  - ``2``: The per-thread default stream.
+  - Any other integer: a ``cudaStream_t`` represented as a Python integer.
+
+  When ``None``, no synchronization is required. See the
+  :ref:`cuda-array-interface-synchronization` section below for further details.
+
+  In a future revision of the interface, this entry may be expanded (or another
+  entry added) so that an event to synchronize on can be specified instead of a
+  stream.
+
+
+.. _cuda-array-interface-synchronization:
+
+Synchronization
+---------------
+
+Definitions
+~~~~~~~~~~~
+
+When discussing synchronization, the following definitions are used:
+
+- *Producer*: The library / object on which ``__cuda_array_interface__`` is
+  accessed.
+- *Consumer*: The library / function that accesses the
+  ``__cuda_array_interface__`` of the Producer.
+- *User Code*: Code that induces a Producer and Consumer to share data through
+  the CAI.
+- *User*: The person writing or maintaining the User Code. The User may
+  implement User Code without knowledge of the CAI, since the CAI accesses can
+  be hidden from their view.
+
+In the following example:
+
+.. code-block:: python
+
+   import cupy
+   from numba import cuda
+
+   @cuda.jit
+   def add(x, y, out):
+       start = cuda.grid(1)
+       stride = cuda.gridsize(1)
+       for i in range(start, x.shape[0], stride):
+           out[i] = x[i] + y[i]
+
+   a = cupy.arange(10)
+   b = a * 2
+   out = cupy.zeros_like(a)
+
+   add[1, 32](a, b, out)
+
+When the ``add`` kernel is launched:
+
+- ``a``, ``b``, ``out`` are Producers.
+- The ``add`` kernel is the Consumer.
+- The User Code is specifically ``add[1, 32](a, b, out)``.
+- The author of the code is the User.
+
+
+Design Motivations
+~~~~~~~~~~~~~~~~~~
+
+Elements of the CAI design related to synchronization seek to fulfill these
+requirements:
+
+1. Producers and Consumers that exchange data through the CAI must be able to do
+   so without data races.
+2. Requirement 1 should be met without requiring the user to be
+   aware of any particulars of the CAI - in other words, exchanging data between
+   Producers and Consumers that operate on data asynchronously should be correct
+   by default.
+
+   - An exception to this requirement is made for Producers and Consumers that
+     explicitly document that the User is required to take additional steps to
+     ensure correctness with respect to synchronization. In this case, Users
+     are required to understand the details of the CUDA Array Interface, and
+     the Producer/Consumer library documentation must specify the steps that
+     Users are required to take.
+
+     Use of this exception should be avoided where possible, as it is provided
+     for libraries that cannot implement the synchronization semantics without
+     the involvement of the User - for example, those interfacing with
+     third-party libraries oblivious to the CUDA Array Interface.
+
+3. Where the User is aware of the particulars of the CAI and implementation
+   details of the Producer and Consumer, they should be able to, at their
+   discretion, override some of the synchronization semantics of the interface
+   to reduce the synchronization overhead. Overriding synchronization semantics
+   implies that:
+
+   - The CAI design, and the design and implementation of the Producer and
+     Consumer do not specify or guarantee correctness with respect to data
+     races.
+   - Instead, the User is responsible for ensuring correctness with respect to
+     data races.
+
+
+Interface Requirements
+~~~~~~~~~~~~~~~~~~~~~~
+
+The ``stream`` entry enables Producers and Consumers to avoid hazards when
+exchanging data. Expected behaviour of the Consumer is as follows:
+
+* When ``stream`` is not present or is ``None``:
+
+  - No synchronization is required on the part of the Consumer.
+  - The Consumer may enqueue operations on the underlying data immediately on
+    any stream.
+
+* When ``stream`` is an integer, its value indicates the stream on which the
+  Producer may have in-progress operations on the data, and which the Consumer
+  is expected to either:
+
+  - Synchronize on before accessing the data, or
+  - Enqueue operations in when accessing the data.
+
+  The Consumer can choose which mechanism to use, with the following
+  considerations:
+
+  - If the Consumer synchronizes on the provided stream prior to accessing the
+    data, then it must ensure that no computation can take place in the provided
+    stream until its operations in its own choice of stream have taken place.
+    This could be achieved by either:
+
+    - Placing a wait on an event in the provided stream that occurs once all
+      of the Consumer's operations on the data are completed, or
+    - Avoiding returning control to the user code until after its operations
+      on its own stream have completed.
+
+  - If the consumer chooses to only enqueue operations on the data in the
+    provided stream, then it may return control to the User code immediately
+    after enqueueing its work, as the work will all be serialized on the
+    exported array's stream. This is sufficient to ensure correctness even if
+    the User code were to induce the Producer to subsequently start enqueueing
+    more work on the same stream.
+
+* If the User has set the Consumer to ignore CAI synchronization semantics, the
+  Consumer may assume it can operate on the data immediately in any stream with
+  no further synchronization, even if the ``stream`` member has an integer
+  value.
+
+
+When exporting an array through the CAI, Producers must ensure that:
+
+* If there is work on the data enqueued in one or more streams, then
+  synchronization on the provided ``stream`` is sufficient to ensure
+  synchronization with all pending work.
+
+  - If the Producer has no enqueued work, or work only enqueued on the stream
+    identified by ``stream``, then this condition is met.
+  - If the Producer has enqueued work on the data on multiple streams, then it
+    must enqueue events on those streams that follow the enqueued work, and
+    then wait on those events in the provided ``stream``. For example:
+
+    1. Work is enqueued by the Producer on streams ``7``, ``9``, and ``15``.
+    2. Events are then enqueued on each of streams ``7``, ``9``, and ``15``.
+    3. Producer then tells stream ``3`` to wait on the events from Step 2, and
+       the ``stream`` entry is set to ``3``.
+
+* If there is no work enqueued on the data, then the ``stream`` entry may be
+  either ``None``, or not provided.
+
+Optionally, to facilitate the User relaxing conformance to synchronization
+semantics:
+
+* Producers may provide a configuration option to always set ``stream`` to
+  ``None``.
+* Consumers may provide a configuration option to ignore the value of ``stream``
+  and act as if it were ``None`` or not provided.  This elides synchronization
+  on the Producer-provided streams, and allows enqueuing work on streams other
+  than that provided by the Producer.
+
+These options should not be set by default in either a Producer or a Consumer.
+The CAI specification does not prescribe the exact mechanism by which these
+options are set, or related options that Producers or Consumers might provide
+to allow the user further control over synchronization behavior.
+
+
+Synchronization in Numba
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Numba is neither strictly a Producer nor a Consumer - it may be used to
+implement either by a User. In order to facilitate the correct implementation of
+synchronization semantics, Numba exhibits the following behaviors related to
+synchronization of the interface:
+
+- When Numba acts as a Consumer (for example when an array-like object is passed
+  to a kernel launch): If ``stream`` is an integer, then Numba will immediately
+  synchronize on the provided ``stream``. A Numba :class:`Device Array
+  <numba.cuda.cudadrv.devicearray.DeviceNDArray>` created from an array-like
+  object has its *default stream* set to the provided stream.
+
+- When Numba acts as a Producer (when the ``__cuda_array_interface__`` property
+  of a Numba CUDA Array is accessed): If the exported CUDA Array has a
+  *default stream*, then it is given as the ``stream`` entry. Otherwise,
+  ``stream`` is set to ``None``.
+
+.. note:: In Numba's terminology, an array's *default stream* is a property
+          specifying the stream that Numba will enqueue asynchronous
+          transfers in if no other stream is provided as an argument to the
+          function invoking the transfer. It is not the same as the `Default
+          Stream
+          <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#default-stream>`_
+          in normal CUDA terminology.
+
+Numba's synchronization behavior results in the following intended
+consequences:
+
+- Exchanging data either as a Producer or a Consumer will be correct without
+  the need for any further action from the User, provided that the other side
+  of the interaction also follows the CAI synchronization semantics.
+- The User is expected to either:
+
+  - Avoid launching kernels or other operations on streams that
+    are not the default stream for their parameters, or
+  - When launching operations on a stream that is not the default stream for
+    a given parameter, they should then insert an event into the stream that
+    they are operating in, and wait on that event in the default stream for
+    the parameter. For an example of this, :ref:`see below
+    <example-multi-streams>`.
+
+The User may override Numba's synchronization behavior by setting the
+environment variable ``NUMBA_CUDA_ARRAY_INTERFACE_SYNC`` or the config variable
+``CUDA_ARRAY_INTERFACE_SYNC`` to ``0`` (see :ref:`GPU Support Environment
+Variables <numba-envvars-gpu-support>`).  When set, Numba will not synchronize
+on the streams of imported arrays, and it is the responsibility of the user to
+ensure correctness with respect to stream synchronization. Synchronization when
+creating a Numba CUDA Array from an object exporting the CUDA Array Interface
+may also be elided by passing ``sync=False`` when creating the Numba CUDA
+Array with :func:`numba.cuda.as_cuda_array` or
+:func:`numba.cuda.from_cuda_array_interface`.
+
+There is scope for Numba's synchronization implementation to be optimized in
+the future, by eliding synchronizations when a kernel or driver API operation
+(e.g.  a memcopy or memset) is launched on the same stream as an imported
+array.
+
+
+.. _example-multi-streams:
+
+An example launching on an array's non-default stream
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example shows how to ensure that a Consumer can safely consume an array
+with a default stream when it is passed to a kernel launched in a different
+stream.
+
+First we need to import Numba and a consumer library (a fictitious library named
+``other_cai_library`` for this example):
+
+.. code-block:: python
+
+   from numba import cuda, int32, void
+   import other_cai_library
+
+Now we'll define a kernel - this initializes the elements of the array, setting
+each entry to its index:
+
+.. code-block:: python
+
+   @cuda.jit(void, int32[::1])
+   def initialize_array(x):
+       i = cuda.grid(1)
+       if i < len(x):
+           x[i] = i
+
+Next we will create two streams:
+
+.. code-block:: python
+
+   array_stream = cuda.stream()
+   kernel_stream = cuda.stream()
+
+Then create an array with one of the streams as its default stream:
+
+.. code-block:: python
+
+   N = 16384
+   x = cuda.device_array(N, stream=array_stream)
+
+Now we launch the kernel in the other stream:
+
+.. code-block:: python
+
+   nthreads = 256
+   nblocks = N // nthreads
+
+   initialize_array[nthreads, nblocks, kernel_stream](x)
+
+If we were to pass ``x`` to a Consumer now, there is a risk that it may operate on
+it in ``array_stream`` whilst the kernel is still running in ``kernel_stream``.
+To prevent operations in ``array_stream`` starting before the kernel launch is
+finished, we create an event and wait on it:
+
+.. code-block:: python
+
+   # Create event
+   evt = cuda.event()
+   # Record the event after the kernel launch in kernel_stream
+   evt.record(kernel_stream)
+   # Wait for the event in array_stream
+   evt.wait(array_stream)
+
+It is now safe for ``other_cai_library`` to consume ``x``:
+
+.. code-block:: python
+
+   other_cai_library.consume(x)
+
+
+Lifetime management
+-------------------
+
+Data
+~~~~
+
+Obtaining the value of the ``__cuda_array_interface__`` property of any object
+has no effect on the lifetime of the object from which it was created. In
+particular, note that the interface has no slot for the owner of the data.
+
+The User code must preserve the lifetime of the object owning the data for as
+long as the Consumer might use it.
+
+
+Streams
+~~~~~~~
+
+Like data, CUDA streams also have a finite lifetime. It is therefore required
+that a Producer exporting data on the interface with an associated stream
+ensures that the exported stream's lifetime is equal to or surpasses the
+lifetime of the object from which the interface was exported.
+
+
+Lifetime management in Numba
+----------------------------
+
+Producing Arrays
+~~~~~~~~~~~~~~~~
+
+Numba takes no steps to maintain the lifetime of an object from which the
+interface is exported - it is the user's responsibility to ensure that the
+underlying object is kept alive for the duration that the exported interface
+might be used.
+
+The lifetime of any Numba-managed stream exported on the interface is guaranteed
+to equal or surpass the lifetime of the underlying object, because the
+underlying object holds a reference to the stream.
+
+.. note:: Numba-managed streams are those created with
+          ``cuda.default_stream()``, ``cuda.legacy_default_stream()``, or
+          ``cuda.per_thread_default_stream()``. Streams not managed by Numba
+          are created from an external stream with ``cuda.external_stream()``.
+
+
+Consuming Arrays
+~~~~~~~~~~~~~~~~
+
+Numba provides two mechanisms for creating device arrays from objects exporting
+the CUDA Array Interface. Which to use depends on whether the created device
+array should maintain the life of the object from which it is created:
+
+- ``as_cuda_array``: This creates a device array that holds a reference to the
+  owning object. As long as a reference to the device array is held, its
+  underlying data will also be kept alive, even if all other references to the
+  original owning object have been dropped.
+- ``from_cuda_array_interface``: This creates a device array with no reference
+  to the owning object by default. The owning object, or some other object to
+  be considered the owner can be passed in the ``owner`` parameter.
+
+The interfaces of these functions are:
+
+.. automethod:: numba.cuda.as_cuda_array
+
+.. automethod:: numba.cuda.from_cuda_array_interface
+
+
+Pointer Attributes
+------------------
+
+Additional information about the data pointer can be retrieved using
+``cuPointerGetAttribute`` or ``cudaPointerGetAttributes``.  Such information
+include:
+
+- the CUDA context that owns the pointer;
+- is the pointer host-accessible?
+- is the pointer a managed memory?
+
+
+.. _NumPy array interface: https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.interface.html#__array_interface__
+
+
+Differences with CUDA Array Interface (Version 0)
+-------------------------------------------------
+
+Version 0 of the CUDA Array Interface did not have the optional **mask**
+attribute to support masked arrays.
+
+
+Differences with CUDA Array Interface (Version 1)
+-------------------------------------------------
+
+Versions 0 and 1 of the CUDA Array Interface neither clarified the
+**strides** attribute for C-contiguous arrays nor specified the treatment for
+zero-size arrays.
+
+
+Differences with CUDA Array Interface (Version 2)
+-------------------------------------------------
+
+Prior versions of the CUDA Array Interface made no statement about
+synchronization.
+
+
+Interoperability
+----------------
+
+The following Python libraries have adopted the CUDA Array Interface:
+
+- Numba
+- `CuPy <https://docs-cupy.chainer.org/en/stable/reference/interoperability.html>`_
+- `PyTorch <https://pytorch.org>`_
+- `PyArrow <https://arrow.apache.org/docs/python/generated/pyarrow.cuda.Context.html#pyarrow.cuda.Context.buffer_from_object>`_
+- `mpi4py <https://mpi4py.readthedocs.io/en/latest/overview.html#support-for-cuda-aware-mpi>`_
+- `ArrayViews <https://github.com/xnd-project/arrayviews>`_
+- `JAX <https://jax.readthedocs.io/en/latest/index.html>`_
+- `PyCUDA <https://documen.tician.de/pycuda/tutorial.html#interoperability-with-other-libraries-using-the-cuda-array-interface>`_
+- `DALI: the NVIDIA Data Loading Library <https://github.com/NVIDIA/DALI>`_ :
+
+    - `TensorGPU objects
+      <https://docs.nvidia.com/deeplearning/dali/user-guide/docs/data_types.html#nvidia.dali.backend.TensorGPU>`_
+      expose the CUDA Array Interface.
+    - `The External Source operator
+      <https://docs.nvidia.com/deeplearning/dali/user-guide/docs/supported_ops.html#nvidia.dali.fn.external_source>`_
+      consumes objects exporting the CUDA Array Interface.
+- The RAPIDS stack:
+
+    - `cuDF <https://rapidsai.github.io/projects/cudf/en/0.11.0/10min-cudf-cupy.html>`_
+    - `cuML <https://docs.rapids.ai/api/cuml/nightly/>`_
+    - `cuSignal <https://github.com/rapidsai/cusignal>`_
+    - `RMM <https://docs.rapids.ai/api/rmm/stable/>`_
+
+If your project is not on this list, please feel free to report it on the `Numba issue tracker <https://github.com/numba/numba/issues>`_.

--- a/docs/source/user/cuda_compilation.rst
+++ b/docs/source/user/cuda_compilation.rst
@@ -1,0 +1,149 @@
+
+.. _cuda_compilation:
+
+Compiling Python functions for use with other languages
+=======================================================
+
+Numba can compile Python code to PTX or LTO-IR so that Python functions can be
+incorporated into CUDA code written in other languages (e.g. C/C++).  It is
+commonly used to support User-Defined Functions written in Python within the
+context of a library or application.
+
+The compilation API can be used without a GPU present, as it uses no driver
+functions and avoids initializing CUDA in the process. It is invoked through
+the following function:
+
+.. autofunction:: numba.cuda.compile
+   :noindex:
+
+If a device is available and compiled code for the compute capability of the
+current device is required (for example when building a JIT compilation
+workflow using Numba), the ``compile_for_current_device`` function can be used:
+
+.. autofunction:: numba.cuda.compile_for_current_device
+   :noindex:
+
+Most users should use the two functions described above; for backwards
+compatibility with existing use cases, the following functions are also
+provided:
+
+.. autofunction:: numba.cuda.compile_ptx
+   :noindex:
+
+.. autofunction:: numba.cuda.compile_ptx_for_current_device
+   :noindex:
+
+
+.. _cuda-using-the-c-abi:
+
+Using the C ABI
+---------------
+
+Numba internally uses its own ABI - this is as described in
+:ref:`device-function-abi`, without the ``extern "C"`` modifier. Calling Numba
+ABI device functions requires three issues to be addressed:
+
+- The name of the function will be mangled according to Numba's ABI rules -
+  these are based on the Itanium C++ ABI rules, but are extended beyond its
+  specifications.
+- The Python return value is expected to be stored into a pointer value passed
+  in the first argument.
+- The return value of the compiled function will contain a status code, instead
+  of the return value of the function. For use of Numba-compiled functions
+  outside of Numba, this can generally be ignored.
+
+A simple way to address all these issues is to compile device functions with
+the C ABI instead. This results in the following:
+
+- The name of the device function in the compiled code can be controlled. By
+  default it will match the name of the function in Python, so it is easy to
+  determine.  This is the function's ``__name__``, rather than
+  ``__qualname__``, because ``__qualname__`` encodes additional scoping
+  information that would make the function name hard to predict, and in a lot
+  of cases, an illegal identifier in C.
+- The returned value of the Python code is placed in the return value of the
+  compiled function.
+- Status codes are ignored / unreported, so they do not need to be handled.
+
+If the name of the compiled function needs to be specified, it can be controlled
+by passing the name in the ``abi_info`` dict, under the key ``'abi_name'``.
+
+Compilation with the C ABI is the default when using the :func:`compile` and
+:func:`compile_for_current_device` functions. The :func:`compile_ptx` and
+:func:`compile_ptx_for_current_device` functions default to the Numba ABI in
+order to maintain compatibility with existing use cases.
+
+
+C and Numba ABI examples
+------------------------
+
+The following function:
+
+.. code:: python
+
+   def add(x, y):
+       return x + y
+
+compiled for the Numba ABI using, for example:
+
+.. code:: python
+
+    ptx, resty = cuda.compile_ptx(add, int32(int32, int32), device=True)
+
+results in PTX where the function prototype is:
+
+.. code:: text
+
+   .visible .func  (.param .b32 func_retval0) _ZN8__main__3addB2v1B94cw51cXTLSUwv1sCUt9Uw1VEw0NRRQPKzLTg4gaGKFsG2oMQGEYakJSQB1PQBk0Bynm21OiwU1a0UoLGhDpQE8oxrNQE_3dEii(
+       .param .b64 _ZN8__main__3addB2v1B94cw51cXTLSUwv1sCUt9Uw1VEw0NRRQPKzLTg4gaGKFsG2oMQGEYakJSQB1PQBk0Bynm21OiwU1a0UoLGhDpQE8oxrNQE_3dEii_param_0,
+       .param .b32 _ZN8__main__3addB2v1B94cw51cXTLSUwv1sCUt9Uw1VEw0NRRQPKzLTg4gaGKFsG2oMQGEYakJSQB1PQBk0Bynm21OiwU1a0UoLGhDpQE8oxrNQE_3dEii_param_1,
+       .param .b32 _ZN8__main__3addB2v1B94cw51cXTLSUwv1sCUt9Uw1VEw0NRRQPKzLTg4gaGKFsG2oMQGEYakJSQB1PQBk0Bynm21OiwU1a0UoLGhDpQE8oxrNQE_3dEii_param_2
+    )
+
+Note that there are three parameters, for the pointer to the return value,
+``x``, and ``y``. The name is mangled in a way that is hard to predict outside
+of Numba internals.
+
+Compiling for the C ABI with:
+
+.. code:: python
+
+   ptx, resty = cuda.compile_ptx(add, int32(int32, int32), device=True, abi="c")
+
+instead results in the following PTX prototype:
+
+.. code:: text
+
+   .visible .func  (.param .b32 func_retval0) add(
+       .param .b32 add_param_0,
+       .param .b32 add_param_1
+   )
+
+The function name matches the Python source function name, and there are exactly
+two parameters, for ``x`` and ``y``. The result of the function is directly
+placed in the return value:
+
+.. code:: text
+
+   add.s32 	%r3, %r2, %r1;
+   st.param.b32 	[func_retval0+0], %r3;
+
+To distinguish one variant of the compiled ``add()`` function from another, the
+following example specifies its ABI name in the ``abi_info`` dict:
+
+.. code:: python
+
+   ptx, resty = cuda.compile_ptx(add, float32(float32, float32), device=True,
+                                 abi="c", abi_info={"abi_name": "add_f32"})
+
+Resulting in the PTX prototype:
+
+.. code:: text
+
+   .visible .func  (.param .b32 func_retval0) add_f32(
+       .param .b32 add_f32_param_0,
+       .param .b32 add_f32_param_1
+   )
+
+which will not clash with definitions by other names (e.g. the variant for
+``int32`` above).

--- a/docs/source/user/cuda_ffi.rst
+++ b/docs/source/user/cuda_ffi.rst
@@ -100,7 +100,7 @@ array arguments using C pointer types.
 
 For example, a function with the following prototype:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/ffi/functions.cu
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/ffi/functions.cu
    :language: C
    :caption: ``numba/cuda/tests/doc_examples/ffi/functions.cu``
    :start-after: magictoken.ex_sum_reduce_proto.begin
@@ -109,7 +109,7 @@ For example, a function with the following prototype:
 
 would be declared as follows:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_ffi.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
    :language: python
    :caption: from ``test_ex_from_buffer`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
    :start-after: magictoken.ex_from_buffer_decl.begin
@@ -121,7 +121,7 @@ To obtain a pointer to array data for passing to foreign functions, use the
 ``from_buffer()`` method of a ``cffi.FFI`` instance. For example, a kernel using
 the ``sum_reduce`` function could be defined as:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_ffi.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
    :language: python
    :caption: from ``test_ex_from_buffer`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
    :start-after: magictoken.ex_from_buffer_kernel.begin
@@ -179,7 +179,7 @@ multiply pairs of numbers from two arrays.
 
 The foreign function is written as follows:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/ffi/functions.cu
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/ffi/functions.cu
    :language: C
    :caption: ``numba/cuda/tests/doc_examples/ffi/functions.cu``
    :start-after: magictoken.ex_mul_f32_f32.begin
@@ -188,7 +188,7 @@ The foreign function is written as follows:
 
 The Python code and kernel are:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_ffi.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_ffi.py
    :language: python
    :caption: from ``test_ex_linking_cu`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
    :start-after: magictoken.ex_linking_cu.begin

--- a/docs/source/user/cuda_ffi.rst
+++ b/docs/source/user/cuda_ffi.rst
@@ -1,0 +1,203 @@
+
+.. _cuda_ffi:
+
+Calling foreign functions from Python kernels
+=============================================
+
+Python kernels can call device functions written in other languages. CUDA C/C++,
+PTX, and binary objects (cubins, fat binaries, etc.) are directly supported;
+sources in other languages must be compiled to PTX first. The constituent parts
+of a Python kernel call to a foreign device function are:
+
+- The device function implementation in a foreign language (e.g. CUDA C).
+- A declaration of the device function in Python.
+- A kernel that links with and calls the foreign function.
+
+.. _device-function-abi:
+
+Device function ABI
+-------------------
+
+Numba's ABI for calling device functions defines the following prototype in
+C/C++:
+
+.. code:: C
+
+   extern "C"
+   __device__ int
+   function(
+     T* return_value,
+     ...
+   );
+
+
+Components of the prototype are as follows:
+
+- ``extern "C"`` is used to prevent name-mangling so that it is easy to declare
+  the function in Python. It can be removed, but then the mangled name must be
+  used in the declaration of the function in Python.
+- ``__device__`` is required to define the function as a device function.
+- The return value is always of type ``int``, and is used to signal whether a
+  Python exception occurred. Since Python exceptions don't occur in foreign
+  functions, this should always be set to 0 by the callee.
+- The first argument is a pointer to the return value of type ``T``, which is
+  allocated in the local address space [#f1]_ and passed in by the caller. If
+  the function returns a value, the pointee should be set by the callee to
+  store the return value.
+- Subsequent arguments should match the types and order of arguments passed to
+  the function from the Python kernel.
+
+Functions written in other languages must compile to PTX that conforms to this
+prototype specification.
+
+A function that accepts two floats and returns a float would have the following
+prototype:
+
+.. code:: C
+
+   extern "C"
+   __device__ int
+   mul_f32_f32(
+     float* return_value,
+     float x,
+     float y
+   );
+
+.. rubric:: Notes
+
+.. [#f1] Care must be taken to ensure that any operations on the return value
+         are applicable to data in the local address space.  Some operations,
+         such as atomics, cannot be performed on data in the local address
+         space.
+
+Declaration in Python
+---------------------
+
+To declare a foreign device function in Python, use :func:`declare_device()
+<numba.cuda.declare_device>`:
+
+.. autofunction:: numba.cuda.declare_device
+
+The returned descriptor name need not match the name of the foreign function.
+For example, when:
+
+.. code::
+
+   mul = cuda.declare_device('mul_f32_f32', 'float32(float32, float32)')
+
+is declared, calling ``mul(a, b)`` inside a kernel will translate into a call to
+``mul_f32_f32(a, b)`` in the compiled code.
+
+Passing pointers
+----------------
+
+Numba's calling convention requires multiple values to be passed for array
+arguments. These include the data pointer along with shape, stride, and other
+information. This is incompatible with the expectations of most C/C++ functions,
+which generally only expect a pointer to the data. To align the calling
+conventions between C device code and Python kernels it is necessary to declare
+array arguments using C pointer types.
+
+For example, a function with the following prototype:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/ffi/functions.cu
+   :language: C
+   :caption: ``numba/cuda/tests/doc_examples/ffi/functions.cu``
+   :start-after: magictoken.ex_sum_reduce_proto.begin
+   :end-before: magictoken.ex_sum_reduce_proto.end
+   :linenos:
+
+would be declared as follows:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_ffi.py
+   :language: python
+   :caption: from ``test_ex_from_buffer`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
+   :start-after: magictoken.ex_from_buffer_decl.begin
+   :end-before: magictoken.ex_from_buffer_decl.end
+   :dedent: 8
+   :linenos:
+
+To obtain a pointer to array data for passing to foreign functions, use the
+``from_buffer()`` method of a ``cffi.FFI`` instance. For example, a kernel using
+the ``sum_reduce`` function could be defined as:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_ffi.py
+   :language: python
+   :caption: from ``test_ex_from_buffer`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
+   :start-after: magictoken.ex_from_buffer_kernel.begin
+   :end-before: magictoken.ex_from_buffer_kernel.end
+   :dedent: 8
+   :linenos:
+
+where ``result`` and ``array`` are both arrays of ``float32`` data.
+
+Linking and Calling functions
+-----------------------------
+
+The ``link`` keyword argument of the :func:`@cuda.jit <numba.cuda.jit>`
+decorator accepts a list of file names specified by absolute path or a path
+relative to the current working directory. Files whose name ends in ``.cu``
+will be compiled with the `NVIDIA Runtime Compiler (NVRTC)
+<https://docs.nvidia.com/cuda/nvrtc/index.html>`_ and linked into the kernel as
+PTX; other files will be passed directly to the CUDA Linker.
+
+For example, the following kernel calls the ``mul()`` function declared above
+with the implementation ``mul_f32_f32()`` in a file called ``functions.cu``:
+
+.. code::
+
+   @cuda.jit(link=['functions.cu'])
+   def multiply_vectors(r, x, y):
+       i = cuda.grid(1)
+
+       if i < len(r):
+           r[i] = mul(x[i], y[i])
+
+
+C/C++ Support
+-------------
+
+Support for compiling and linking of CUDA C/C++ code is provided through the use
+of NVRTC subject to the following considerations:
+
+- It is only available when using the NVIDIA Bindings. See
+  :envvar:`NUMBA_CUDA_USE_NVIDIA_BINDING`.
+- A suitable version of the NVRTC library for the installed version of the
+  NVIDIA CUDA Bindings must be available.
+- The CUDA include path is assumed by default to be ``/usr/local/cuda/include``
+  on Linux and ``$env:CUDA_PATH\include`` on Windows. It can be modified using
+  the environment variable :envvar:`NUMBA_CUDA_INCLUDE_PATH`.
+- The CUDA include directory will be made available to NVRTC on the include
+  path; additional includes are not supported.
+
+
+Complete Example
+----------------
+
+This example demonstrates calling a foreign function written in CUDA C to
+multiply pairs of numbers from two arrays.
+
+The foreign function is written as follows:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/ffi/functions.cu
+   :language: C
+   :caption: ``numba/cuda/tests/doc_examples/ffi/functions.cu``
+   :start-after: magictoken.ex_mul_f32_f32.begin
+   :end-before: magictoken.ex_mul_f32_f32.end
+   :linenos:
+
+The Python code and kernel are:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_ffi.py
+   :language: python
+   :caption: from ``test_ex_linking_cu`` in ``numba/cuda/tests/doc_examples/test_ffi.py``
+   :start-after: magictoken.ex_linking_cu.begin
+   :end-before: magictoken.ex_linking_cu.end
+   :dedent: 8
+   :linenos:
+
+.. note::
+
+  The example above is minimal in order to illustrate a foreign function call -
+  it would not be expected to be particularly performant due to the small grid
+  and light workload of the foreign function.

--- a/docs/source/user/cudapysupported.rst
+++ b/docs/source/user/cudapysupported.rst
@@ -1,0 +1,353 @@
+========================================
+Supported Python features in CUDA Python
+========================================
+
+This page lists the Python features supported in the CUDA Python.  This includes
+all kernel and device functions compiled with ``@cuda.jit`` and other higher
+level Numba decorators that targets the CUDA GPU.
+
+Language
+========
+
+Execution Model
+---------------
+
+CUDA Python maps directly to the *single-instruction multiple-thread*
+execution (SIMT) model of CUDA.  Each instruction is implicitly
+executed by multiple threads in parallel.  With this execution model, array
+expressions are less useful because we don't want multiple threads to perform
+the same task.  Instead, we want threads to perform a task in a cooperative
+fashion.
+
+For details please consult the
+`CUDA Programming Guide
+<http://docs.nvidia.com/cuda/cuda-c-programming-guide/#programming-model>`_.
+
+Floating Point Error Model
+--------------------------
+
+By default, CUDA Python kernels execute with the NumPy error model. In this
+model, division by zero raises no exception and instead produces a result of
+``inf``, ``-inf`` or ``nan``. This differs from the normal Python error model,
+in which division by zero raises a ``ZeroDivisionError``.
+
+When debug is enabled (by passing ``debug=True`` to the
+:func:`@cuda.jit <numba.cuda.jit>` decorator), the Python error model is used.
+This allows division-by-zero errors during kernel execution to be identified.
+
+Constructs
+----------
+
+The following Python constructs are not supported:
+
+* Exception handling (``try .. except``, ``try .. finally``)
+* Context management (the ``with`` statement)
+* Comprehensions (either list, dict, set or generator comprehensions)
+* Generator (any ``yield`` statements)
+
+The ``raise`` and ``assert`` statements are supported, with the following
+constraints:
+
+- They can only be used in kernels, not in device functions.
+- They only have an effect when ``debug=True`` is passed to the
+  :func:`@cuda.jit <numba.cuda.jit>` decorator. This is similar to the behavior
+  of the ``assert`` keyword in CUDA C/C++, which is ignored unless compiling
+  with device debug turned on.
+
+
+Printing of strings, integers, and floats is supported, but printing is an
+asynchronous operation - in order to ensure that all output is printed after a
+kernel launch, it is necessary to call :func:`numba.cuda.synchronize`. Eliding
+the call to ``synchronize`` is acceptable, but output from a kernel may appear
+during other later driver operations (e.g. subsequent kernel launches, memory
+transfers, etc.), or fail to appear before the program execution completes. Up
+to 32 arguments may be passed to the ``print`` function - if more are passed
+then a format string will be emitted instead and a warning will be produced.
+This is due to a general limitation in CUDA printing, as outlined in the
+`section on limitations in printing
+<https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#limitations>`_
+in the CUDA C++ Programming Guide.
+
+
+Recursion
+---------
+
+Self-recursive device functions are supported, with the constraint that
+recursive calls must have the same argument types as the initial call to
+the function. For example, the following form of recursion is supported:
+
+.. code:: python
+
+   @cuda.jit("int64(int64)", device=True)
+   def fib(n):
+       if n < 2:
+           return n
+       return fib(n - 1) + fib(n - 2)
+
+(the ``fib`` function always has an ``int64`` argument), whereas the following
+is unsupported:
+
+.. code:: python
+
+   # Called with x := int64, y := float64
+   @cuda.jit
+   def type_change_self(x, y):
+       if x > 1 and y > 0:
+           return x + type_change_self(x - y, y)
+       else:
+           return y
+
+The outer call to ``type_change_self`` provides ``(int64, float64)`` arguments,
+but the inner call uses ``(float64, float64)`` arguments (because ``x - y`` /
+``int64 - float64`` results in a ``float64`` type). Therefore, this function is
+unsupported.
+
+Mutual recursion between functions (e.g. where a function ``func1()`` calls
+``func2()`` which again calls ``func1()``) is unsupported.
+
+.. note::
+
+   The call stack in CUDA is typically quite limited in size, so it is easier
+   to overflow it with recursive calls on CUDA devices than it is on CPUs.
+
+   Stack overflow will result in an Unspecified Launch Failure (ULF) during
+   kernel execution.  In order to identify whether a ULF is due to stack
+   overflow, programs can be run under `Compute Sanitizer
+   <https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html>`_,
+   which explicitly states when stack overflow has occurred.
+
+.. _cuda-built-in-types:
+
+Built-in types
+===============
+
+The following built-in types support are inherited from CPU nopython mode.
+
+* int
+* float
+* complex
+* bool
+* None
+* tuple
+* Enum, IntEnum
+
+See :ref:`nopython built-in types <pysupported-builtin-types>`.
+
+There is also some very limited support for character sequences (bytes and
+unicode strings) used in NumPy arrays. Note that this support can only be used
+with CUDA 11.2 onwards.
+
+Built-in functions
+==================
+
+The following built-in functions are supported:
+
+* :func:`abs`
+* :class:`bool`
+* :class:`complex`
+* :func:`enumerate`
+* :class:`float`
+* :class:`int`: only the one-argument form
+* :func:`len`
+* :func:`min`: only the multiple-argument form
+* :func:`max`: only the multiple-argument form
+* :func:`pow`
+* :class:`range`
+* :func:`round`
+* :func:`zip`
+
+
+Standard library modules
+========================
+
+
+``cmath``
+---------
+
+The following functions from the :mod:`cmath` module are supported:
+
+* :func:`cmath.acos`
+* :func:`cmath.acosh`
+* :func:`cmath.asin`
+* :func:`cmath.asinh`
+* :func:`cmath.atan`
+* :func:`cmath.atanh`
+* :func:`cmath.cos`
+* :func:`cmath.cosh`
+* :func:`cmath.exp`
+* :func:`cmath.isfinite`
+* :func:`cmath.isinf`
+* :func:`cmath.isnan`
+* :func:`cmath.log`
+* :func:`cmath.log10`
+* :func:`cmath.phase`
+* :func:`cmath.polar`
+* :func:`cmath.rect`
+* :func:`cmath.sin`
+* :func:`cmath.sinh`
+* :func:`cmath.sqrt`
+* :func:`cmath.tan`
+* :func:`cmath.tanh`
+
+``math``
+--------
+
+The following functions from the :mod:`math` module are supported:
+
+* :func:`math.acos`
+* :func:`math.asin`
+* :func:`math.atan`
+* :func:`math.acosh`
+* :func:`math.asinh`
+* :func:`math.atanh`
+* :func:`math.cos`
+* :func:`math.sin`
+* :func:`math.tan`
+* :func:`math.hypot`
+* :func:`math.cosh`
+* :func:`math.sinh`
+* :func:`math.tanh`
+* :func:`math.atan2`
+* :func:`math.erf`
+* :func:`math.erfc`
+* :func:`math.exp`
+* :func:`math.expm1`
+* :func:`math.fabs`
+* :func:`math.frexp`
+* :func:`math.ldexp`
+* :func:`math.gamma`
+* :func:`math.lgamma`
+* :func:`math.log`
+* :func:`math.log2`
+* :func:`math.log10`
+* :func:`math.log1p`
+* :func:`math.sqrt`
+* :func:`math.remainder`
+* :func:`math.pow`
+* :func:`math.ceil`
+* :func:`math.floor`
+* :func:`math.copysign`
+* :func:`math.fmod`
+* :func:`math.modf`
+* :func:`math.isnan`
+* :func:`math.isinf`
+* :func:`math.isfinite`
+
+
+``operator``
+------------
+
+The following functions from the :mod:`operator` module are supported:
+
+* :func:`operator.add`
+* :func:`operator.and_`
+* :func:`operator.eq`
+* :func:`operator.floordiv`
+* :func:`operator.ge`
+* :func:`operator.gt`
+* :func:`operator.iadd`
+* :func:`operator.iand`
+* :func:`operator.ifloordiv`
+* :func:`operator.ilshift`
+* :func:`operator.imod`
+* :func:`operator.imul`
+* :func:`operator.invert`
+* :func:`operator.ior`
+* :func:`operator.ipow`
+* :func:`operator.irshift`
+* :func:`operator.isub`
+* :func:`operator.itruediv`
+* :func:`operator.ixor`
+* :func:`operator.le`
+* :func:`operator.lshift`
+* :func:`operator.lt`
+* :func:`operator.mod`
+* :func:`operator.mul`
+* :func:`operator.ne`
+* :func:`operator.neg`
+* :func:`operator.not_`
+* :func:`operator.or_`
+* :func:`operator.pos`
+* :func:`operator.pow`
+* :func:`operator.rshift`
+* :func:`operator.sub`
+* :func:`operator.truediv`
+* :func:`operator.xor`
+
+.. _cuda_numpy_support:
+
+NumPy support
+=============
+
+Due to the CUDA programming model, dynamic memory allocation inside a kernel is
+inefficient and is often not needed.  Numba disallows any memory allocating features.
+This disables a large number of NumPy APIs.  For best performance, users should write
+code such that each thread is dealing with a single element at a time.
+
+Supported NumPy features:
+
+* accessing `ndarray` attributes `.shape`, `.strides`, `.ndim`, `.size`, etc..
+* indexing and slicing works.
+* A subset of ufuncs are supported, but the output array must be passed in as a
+  positional argument (see :ref:`cuda_ufunc_call_example`). Note that ufuncs
+  execute sequentially in each thread - there is no automatic parallelisation
+  of ufuncs across threads over the elements of an input array.
+
+  The following ufuncs are supported:
+
+  * :func:`numpy.sin`
+  * :func:`numpy.cos`
+  * :func:`numpy.tan`
+  * :func:`numpy.arcsin`
+  * :func:`numpy.arccos`
+  * :func:`numpy.arctan`
+  * :func:`numpy.arctan2`
+  * :func:`numpy.hypot`
+  * :func:`numpy.sinh`
+  * :func:`numpy.cosh`
+  * :func:`numpy.tanh`
+  * :func:`numpy.arcsinh`
+  * :func:`numpy.arccosh`
+  * :func:`numpy.arctanh`
+  * :func:`numpy.deg2rad`
+  * :func:`numpy.radians`
+  * :func:`numpy.rad2deg`
+  * :func:`numpy.degrees`
+  * :func:`numpy.greater`
+  * :func:`numpy.greater_equal`
+  * :func:`numpy.less`
+  * :func:`numpy.less_equal`
+  * :func:`numpy.not_equal`
+  * :func:`numpy.equal`
+  * :func:`numpy.log`
+  * :func:`numpy.log2`
+  * :func:`numpy.log10`
+  * :func:`numpy.logical_and`
+  * :func:`numpy.logical_or`
+  * :func:`numpy.logical_xor`
+  * :func:`numpy.logical_not`
+  * :func:`numpy.maximum`
+  * :func:`numpy.minimum`
+  * :func:`numpy.fmax`
+  * :func:`numpy.fmin`
+  * :func:`numpy.bitwise_and`
+  * :func:`numpy.bitwise_or`
+  * :func:`numpy.bitwise_xor`
+  * :func:`numpy.invert`
+  * :func:`numpy.bitwise_not`
+  * :func:`numpy.left_shift`
+  * :func:`numpy.right_shift`
+
+Unsupported NumPy features:
+
+* array creation APIs.
+* array methods.
+* functions that returns a new array.
+
+
+CFFI support
+============
+
+The ``from_buffer()`` method of ``cffi.FFI`` objects is supported. This is
+useful for obtaining a pointer that can be passed to external C / C++ / PTX
+functions (see the :ref:`CUDA FFI documentation <cuda_ffi>`).

--- a/docs/source/user/device-functions.rst
+++ b/docs/source/user/device-functions.rst
@@ -1,0 +1,15 @@
+
+Writing Device Functions
+========================
+
+CUDA device functions can only be invoked from within the device (by a kernel
+or another device function).  To define a device function::
+
+    from numba import cuda
+
+    @cuda.jit(device=True)
+    def a_device_function(a, b):
+        return a + b
+
+Unlike a kernel function, a device function can return a value like normal
+functions.

--- a/docs/source/user/device-management.rst
+++ b/docs/source/user/device-management.rst
@@ -1,0 +1,92 @@
+
+Device management
+=================
+
+For multi-GPU machines, users may want to select which GPU to use.
+By default the CUDA driver selects the fastest GPU as the device 0,
+which is the default device used by Numba.
+
+The features introduced on this page are generally not of interest
+unless working with systems hosting/offering more than one CUDA-capable GPU.
+
+Device Selection
+----------------
+
+If at all required, device selection must be done before any CUDA feature is
+used.
+
+::
+
+    from numba import cuda
+    cuda.select_device(0)
+
+The device can be closed by:
+
+::
+
+    cuda.close()
+
+Users can then create a new context with another device.
+
+::
+
+    cuda.select_device(1)  # assuming we have 2 GPUs
+
+
+.. function:: numba.cuda.select_device(device_id)
+   :noindex:
+
+   Create a new CUDA context for the selected *device_id*.  *device_id*
+   should be the number of the device (starting from 0; the device order
+   is determined by the CUDA libraries).  The context is associated with
+   the current thread.  Numba currently allows only one context per thread.
+
+   If successful, this function returns a device instance.
+
+   .. XXX document device instances?
+
+
+.. function:: numba.cuda.close
+   :noindex:
+
+   Explicitly close all contexts in the current thread.
+
+   .. note::
+      Compiled functions are associated with the CUDA context.
+      This makes it not very useful to close and create new devices, though it
+      is certainly useful for choosing which device to use when the machine
+      has multiple GPUs.
+
+The Device List
+===============
+
+The Device List is a list of all the GPUs in the system, and can be indexed to
+obtain a context manager that ensures execution on the selected GPU.
+
+.. attribute:: numba.cuda.gpus
+   :noindex:
+.. attribute:: numba.cuda.cudadrv.devices.gpus
+
+:py:data:`numba.cuda.gpus` is an instance of the ``_DeviceList`` class, from
+which the current GPU context can also be retrieved:
+
+.. autoclass:: numba.cuda.cudadrv.devices._DeviceList
+    :members: current
+    :noindex:
+
+
+Device UUIDs
+============
+
+The UUID of a device (equal to that returned by ``nvidia-smi -L``) is available
+in the :attr:`uuid <numba.cuda.cudadrv.driver.Device.uuid>` attribute of a CUDA
+device object.
+
+For example, to obtain the UUID of the current device:
+
+.. code-block:: python
+
+   dev = cuda.current_context().device
+   # prints e.g. "GPU-e6489c45-5b68-3b03-bab7-0e7c8e809643"
+   print(dev.uuid)
+

--- a/docs/source/user/examples.rst
+++ b/docs/source/user/examples.rst
@@ -1,0 +1,546 @@
+
+========
+Examples
+========
+
+.. _cuda-vecadd:
+
+Vector Addition
+===============
+This example uses Numba to create on-device arrays and a vector addition kernel;
+it is a warmup for learning how to write GPU kernels using Numba. We'll begin
+with some required imports:
+
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+   :language: python
+   :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
+   :start-after: ex_vecadd.import.begin
+   :end-before: ex_vecadd.import.end
+   :dedent: 8
+   :linenos:
+
+The following function is the kernel. Note that it is defined in terms of Python
+variables with unspecified types. When the kernel is launched, Numba will
+examine the types of the arguments that are passed at runtime and generate a
+CUDA kernel specialized for them.
+
+Note that Numba kernels do not return values and must write any output into
+arrays passed in as parameters (this is similar to the requirement that CUDA
+C/C++ kernels have ``void`` return type). Here we pass in ``c`` for the results
+to be written into.
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+   :language: python
+   :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
+   :start-after: ex_vecadd.kernel.begin
+   :end-before: ex_vecadd.kernel.end
+   :dedent: 8
+   :linenos:
+
+:func:`cuda.to_device() <numba.cuda.to_device>` can be used create device-side
+copies of arrays.  :func:`cuda.device_array_like()
+<numba.cuda.device_array_like>` creates an uninitialized array of the same shape
+and type as an existing array.  Here we transfer two vectors and create an empty
+vector to hold our results:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+   :language: python
+   :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
+   :start-after: ex_vecadd.allocate.begin
+   :end-before: ex_vecadd.allocate.end
+   :dedent: 8
+   :linenos:
+
+A call to :meth:`forall() <numba.cuda.dispatcher.Dispatcher.forall>` generates
+an appropriate launch configuration with a 1D grid (see
+:ref:`cuda-kernel-invocation`) for a given data size and is often the simplest
+way of launching a kernel:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+   :language: python
+   :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
+   :start-after: ex_vecadd.forall.begin
+   :end-before: ex_vecadd.forall.end
+   :dedent: 8
+   :linenos:
+
+This prints:
+
+.. code-block:: none
+
+   [0.73548323 1.32061059 0.12582968 ... 1.25925809 1.49335059 1.59315414]
+
+One can also configure the grid manually using the subscripting syntax. The
+following example launches a grid with sufficient threads to operate on every
+vector element:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+   :language: python
+   :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
+   :start-after: ex_vecadd.launch.begin
+   :end-before: ex_vecadd.launch.end
+   :dedent: 8
+   :linenos:
+
+This also prints:
+
+.. code-block:: none
+
+   [0.73548323 1.32061059 0.12582968 ... 1.25925809 1.49335059 1.59315414]
+
+.. _cuda-laplace:
+
+1D Heat Equation
+=====================
+This example solves Laplace's equation in one dimension for a certain set of initial
+conditions and boundary conditions. A full discussion of Laplace's equation is out of
+scope for this documentation, but it will suffice to say that it describes how heat
+propagates through an object over time. It works by discretizing the problem in two ways:
+
+1. The domain is partitioned into a mesh of points that each have an individual temperature.
+2. Time is partitioned into discrete intervals that are advanced forward sequentially.
+
+Then, the following assumption is applied: The temperature of a point after some interval 
+has passed is some weighted average of the temperature of the points that are directly
+adjacent to it. Intuitively, if all the points in the domain are very hot
+and a single point in the middle is very cold, as time passes, the hot points will cause
+the cold one to heat up and the cold point will cause the surrounding hot pieces to cool
+slightly. Simply put, the heat spreads throughout the object.
+
+We can implement this simulation using a Numba kernel. Let's start simple by assuming
+we have a one dimensional object which we'll represent with an array of values. The position 
+of the element in the array is the position of a point within the object, and the value
+of the element represents the temperature. 
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_laplace.py
+   :language: python
+   :caption: from ``test_ex_laplace`` in ``numba/cuda/tests/doc_examples/test_laplace.py``
+   :start-after: ex_laplace.import.begin
+   :end-before: ex_laplace.import.end
+   :dedent: 8
+   :linenos:
+
+
+Some initial setup here. Let's make one point in the center of the object very hot.
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_laplace.py
+   :language: python
+   :caption: from ``test_ex_laplace`` in ``numba/cuda/tests/doc_examples/test_laplace.py``
+   :start-after: ex_laplace.allocate.begin
+   :end-before: ex_laplace.allocate.end
+   :dedent: 8
+   :linenos:
+
+The initial state of the problem can be visualized as:
+
+.. image:: laplace_initial.svg
+
+In our kernel each thread will be responsible for managing the temperature update for a single element
+in a loop over the desired number of timesteps. The kernel is below. Note the use of cooperative group
+synchronization and the use of two buffers swapped at each iteration to avoid race conditions. See 
+:func:`numba.cuda.cg.this_grid() <numba.cuda.cg.this_grid>` for details.
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_laplace.py
+   :language: python
+   :caption: from ``test_ex_laplace`` in ``numba/cuda/tests/doc_examples/test_laplace.py``
+   :start-after: ex_laplace.kernel.begin
+   :end-before: ex_laplace.kernel.end
+   :dedent: 8
+   :linenos:
+
+
+Calling the kernel:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_laplace.py
+   :language: python
+   :caption: from ``test_ex_laplace`` in ``numba/cuda/tests/doc_examples/test_laplace.py``
+   :start-after: ex_laplace.launch.begin
+   :end-before: ex_laplace.launch.end
+   :dedent: 8
+   :linenos:
+
+
+Plotting the final data shows an arc that is highest where
+the object was hot initially and gradually sloping down to zero towards the
+edges where the temperature is fixed at zero. In the limit of infinite time,
+the arc will flatten out completely.
+
+.. image:: laplace_final.svg
+
+.. _cuda_reduction_shared:
+
+Shared Memory Reduction
+=======================
+Numba exposes many CUDA features, including :ref:`shared memory
+<cuda-shared-memory>`. To demonstrate shared memory, let's reimplement a
+famous CUDA solution for summing a vector which works by "folding" the data up
+using a successively smaller number of threads.
+
+
+Note that this is a fairly naive implementation, and there are more efficient ways of implementing reductions
+using Numba - see :ref:`cuda_montecarlo` for an example.
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_reduction.py
+   :language: python
+   :caption: from ``test_ex_reduction`` in ``numba/cuda/tests/doc_examples/test_reduction.py``
+   :start-after: ex_reduction.import.begin
+   :end-before: ex_reduction.import.end
+   :dedent: 8
+   :linenos:
+
+Let's create some one dimensional data that we'll use to demonstrate the
+kernel itself:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_reduction.py
+   :language: python
+   :caption: from ``test_ex_reduction`` in ``numba/cuda/tests/doc_examples/test_reduction.py``
+   :start-after: ex_reduction.allocate.begin
+   :end-before: ex_reduction.allocate.end
+   :dedent: 8
+   :linenos:
+
+
+Here is a version of the kernel implemented using Numba:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_reduction.py
+   :language: python
+   :caption: from ``test_ex_reduction`` in ``numba/cuda/tests/doc_examples/test_reduction.py``
+   :start-after: ex_reduction.kernel.begin
+   :end-before: ex_reduction.kernel.end
+   :dedent: 8
+   :linenos:
+
+We can run kernel and verify that the same result is obtained through
+summing data on the host as follows:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_reduction.py
+   :language: python
+   :caption: from ``test_ex_reduction`` in ``numba/cuda/tests/doc_examples/test_reduction.py``
+   :start-after: ex_reduction.launch.begin
+   :end-before: ex_reduction.launch.end
+   :dedent: 8
+   :linenos:
+
+This algorithm can be greatly improved upon by redesigning the inner loop
+to use sequential memory accesses, and even further by using strategies that
+keep more threads active and working, since in this example most threads quickly
+become idle.
+
+.. _cuda_sessionization:
+
+Dividing Click Data into Sessions
+=================================
+
+
+A common problem in business analytics is that of grouping the activity of users of an online platform into
+sessions, called "sessionization". The idea is that users generally traverse through a website and perform
+various actions (clicking something, filling out a form, etc.) in discrete groups. Perhaps a customer spends
+some time shopping for an item in the morning and then again at night - often the business is interested in
+treating these periods as separate interactions with their service, and this creates the problem of 
+programmatically splitting up activity in some agreed-upon way.
+
+Here we'll illustrate how to write a Numba kernel to solve this problem. We'll start with data 
+containing two fields: let ``user_id`` represent a unique ID corresponding to an individual customer, and let 
+``action_time`` be a time that some unknown action was taken on the service. Right now, we'll assume there's 
+only one type of action, so all there is to know is when it happened.
+
+Our goal will be to create a new column called ``session_id``, which contains a label corresponding to a unique 
+session. We'll define the boundary between sessions as when there has been at least one hour between clicks.
+
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_sessionize.py
+   :language: python
+   :caption: from ``test_ex_sessionize`` in ``numba/cuda/tests/doc_examples/test_sessionize.py``
+   :start-after: ex_sessionize.import.begin
+   :end-before: ex_sessionize.import.end
+   :dedent: 8
+   :linenos:
+   
+Here is a solution using Numba:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_sessionize.py
+   :language: python
+   :caption: from ``test_ex_sessionize`` in ``numba/cuda/tests/doc_examples/test_sessionize.py``
+   :start-after: ex_sessionize.kernel.begin
+   :end-before: ex_sessionize.kernel.end
+   :dedent: 8
+   :linenos:
+
+Let's generate some data and try out the kernel:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_sessionize.py
+   :language: python
+   :caption: from ``test_ex_sessionize`` in ``numba/cuda/tests/doc_examples/test_sessionize.py``
+   :start-after: ex_sessionize.allocate.begin
+   :end-before: ex_sessionize.allocate.end
+   :dedent: 8
+   :linenos:
+
+As can be seen above, the kernel successfully divided the first three datapoints from the second three for the first user ID,
+and a similar pattern is seen throughout.
+
+.. _cuda_reuse_function:
+
+JIT Function CPU-GPU Compatibility
+==================================
+
+This example demonstrates how ``numba.jit`` can be used to jit compile a function for the CPU, while at the same time making 
+it available for use inside CUDA kernels. This can be very useful for users that are migrating workflows from CPU to GPU as 
+they can directly reuse potential business logic with fewer code changes.
+
+Take the following example function:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+   :language: python
+   :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
+   :start-after: ex_cpu_gpu_compat.define.begin
+   :end-before: ex_cpu_gpu_compat.define.end
+   :dedent: 8
+   :linenos:
+
+The function ``business_logic`` can be run standalone in compiled form on the CPU:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+   :language: python
+   :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
+   :start-after: ex_cpu_gpu_compat.cpurun.begin
+   :end-before: ex_cpu_gpu_compat.cpurun.end
+   :dedent: 8
+   :linenos:
+
+It can also be directly reused threadwise inside a GPU kernel. For example one may 
+generate some vectors to represent ``x``, ``y``, and ``z``:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+   :language: python
+   :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
+   :start-after: ex_cpu_gpu_compat.allocate.begin
+   :end-before: ex_cpu_gpu_compat.allocate.end
+   :dedent: 8
+   :linenos:
+
+And a numba kernel referencing the decorated function:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+   :language: python
+   :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
+   :start-after: ex_cpu_gpu_compat.usegpu.begin
+   :end-before: ex_cpu_gpu_compat.usegpu.end
+   :dedent: 8
+   :linenos:
+
+This kernel can be invoked in the normal way:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+   :language: python
+   :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
+   :start-after: ex_cpu_gpu_compat.launch.begin
+   :end-before: ex_cpu_gpu_compat.launch.end
+   :dedent: 8
+   :linenos:
+
+.. _cuda_montecarlo:
+
+Monte Carlo Integration
+=======================
+
+This example shows how to use Numba to approximate the value of a definite integral by rapidly generating 
+random numbers on the GPU. A detailed description of the mathematical mechanics of Monte Carlo integration
+is out of the scope of the example, but it can briefly be described as an averaging process where the area 
+under the curve is approximated by taking the average of many rectangles formed by its function values.
+
+In addition, this example shows how to perform reductions in numba using the 
+:func:`cuda.reduce() <numba.cuda.Reduce>` API.
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+   :language: python
+   :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
+   :start-after: ex_montecarlo.import.begin
+   :end-before: ex_montecarlo.import.end
+   :dedent: 8
+   :linenos:
+
+Let's create a variable to control the number of samples drawn:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+   :language: python
+   :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
+   :start-after: ex_montecarlo.define.begin
+   :end-before: ex_montecarlo.define.end
+   :dedent: 8
+   :linenos:
+
+
+The following kernel implements the main integration routine:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+   :language: python
+   :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
+   :start-after: ex_montecarlo.kernel.begin
+   :end-before: ex_montecarlo.kernel.end
+   :dedent: 8
+   :linenos:
+
+This convenience function calls the kernel performs some
+preprocessing and post processing steps. Note the use of Numba's reduction API to
+take sum of the array and compute the final result:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+   :language: python
+   :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
+   :start-after: ex_montecarlo.callfunc.begin
+   :end-before: ex_montecarlo.callfunc.end
+   :dedent: 8
+   :linenos:
+
+
+We can now use ``mc_integrate`` to compute the definite integral of this function between
+two limits:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+   :language: python
+   :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
+   :start-after: ex_montecarlo.launch.begin
+   :end-before: ex_montecarlo.launch.end
+   :dedent: 8
+   :linenos:
+
+
+.. _cuda-matmul:
+
+Matrix multiplication
+=====================
+First, import the modules needed for this example:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+   :language: python
+   :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
+   :start-after: magictoken.ex_import.begin
+   :end-before: magictoken.ex_import.end
+   :dedent: 8
+   :linenos:
+
+Here is a naïve implementation of matrix multiplication using a CUDA kernel:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+   :language: python
+   :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
+   :start-after: magictoken.ex_matmul.begin
+   :end-before: magictoken.ex_matmul.end
+   :dedent: 8
+   :linenos:
+
+An example usage of this function is as follows:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+   :language: python
+   :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
+   :start-after: magictoken.ex_run_matmul.begin
+   :end-before: magictoken.ex_run_matmul.end
+   :dedent: 8
+   :linenos:
+
+This implementation is straightforward and intuitive but performs poorly,
+because the same matrix elements will be loaded multiple times from device
+memory, which is slow (some devices may have transparent data caches, but
+they may not be large enough to hold the entire inputs at once).
+
+It will be faster if we use a blocked algorithm to reduce accesses to the
+device memory.  CUDA provides a fast :ref:`shared memory <cuda-shared-memory>`
+for threads in a block to cooperatively compute on a task.  The following
+implements a faster version of the square matrix multiplication using shared
+memory:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+   :language: python
+   :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
+   :start-after: magictoken.ex_fast_matmul.begin
+   :end-before: magictoken.ex_fast_matmul.end
+   :dedent: 8
+   :linenos:
+
+
+Because the shared memory is a limited resource, the code preloads a small
+block at a time from the input arrays.  Then, it calls
+:func:`~numba.cuda.syncthreads` to wait until all threads have finished
+preloading and before doing the computation on the shared memory.
+It synchronizes again after the computation to ensure all threads
+have finished with the data in shared memory before overwriting it
+in the next loop iteration.
+
+An example usage of the ``fast_matmul`` function is as follows:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+   :language: python
+   :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
+   :start-after: magictoken.ex_run_fast_matmul.begin
+   :end-before: magictoken.ex_run_fast_matmul.end
+   :dedent: 8
+   :linenos:
+
+
+This passes a :ref:`CUDA memory check test <debugging-cuda-python-code>`, which
+can help with debugging. Running the code above produces the following output:
+
+.. code-block:: none
+
+    $ python fast_matmul.py
+    [[ 6.  6.  6.  6.]
+    [22. 22. 22. 22.]
+    [38. 38. 38. 38.]
+    [54. 54. 54. 54.]]
+    [[ 6.  6.  6.  6.]
+    [22. 22. 22. 22.]
+    [38. 38. 38. 38.]
+    [54. 54. 54. 54.]]
+
+.. note:: For high performance matrix multiplication in CUDA, see also the `CuPy implementation <https://docs.cupy.dev/en/stable/reference/generated/cupy.matmul.html>`_.
+
+The approach outlined here generalizes to non-square matrix multiplication as
+follows by adjusting the ``blockspergrid`` variable:
+
+Again, here is an example usage:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+   :language: python
+   :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
+   :start-after: magictoken.ex_run_nonsquare.begin
+   :end-before: magictoken.ex_run_nonsquare.end
+   :dedent: 8
+   :linenos:
+
+and the corresponding output:
+
+.. code-block:: none
+
+  $ python nonsquare_matmul.py
+  [[ 253.  253.  253.  253.  253.  253.  253.]
+  [ 782.  782.  782.  782.  782.  782.  782.]
+  [1311. 1311. 1311. 1311. 1311. 1311. 1311.]
+  [1840. 1840. 1840. 1840. 1840. 1840. 1840.]
+  [2369. 2369. 2369. 2369. 2369. 2369. 2369.]]
+  [[ 253.  253.  253.  253.  253.  253.  253.]
+  [ 782.  782.  782.  782.  782.  782.  782.]
+  [1311. 1311. 1311. 1311. 1311. 1311. 1311.]
+  [1840. 1840. 1840. 1840. 1840. 1840. 1840.]
+  [2369. 2369. 2369. 2369. 2369. 2369. 2369.]]
+
+
+.. _cuda_ufunc_call_example:
+
+Calling a NumPy UFunc
+=====================
+
+UFuncs supported in the CUDA target (see :ref:`cuda_numpy_support`) can be
+called inside kernels, but the output array must be passed in as a positional
+argument. The following example demonstrates a call to :func:`np.sin` inside a
+kernel following this pattern:
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_ufunc.py
+   :language: python
+   :caption: from ``test_ex_cuda_ufunc_call`` in ``numba/cuda/tests/doc_examples/test_ufunc.py``
+   :start-after: ex_cuda_ufunc.begin
+   :end-before: ex_cuda_ufunc.end
+   :dedent: 8
+   :linenos:

--- a/docs/source/user/examples.rst
+++ b/docs/source/user/examples.rst
@@ -12,7 +12,7 @@ it is a warmup for learning how to write GPU kernels using Numba. We'll begin
 with some required imports:
 
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_vecadd.py
    :language: python
    :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
    :start-after: ex_vecadd.import.begin
@@ -30,7 +30,7 @@ arrays passed in as parameters (this is similar to the requirement that CUDA
 C/C++ kernels have ``void`` return type). Here we pass in ``c`` for the results
 to be written into.
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_vecadd.py
    :language: python
    :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
    :start-after: ex_vecadd.kernel.begin
@@ -44,7 +44,7 @@ copies of arrays.  :func:`cuda.device_array_like()
 and type as an existing array.  Here we transfer two vectors and create an empty
 vector to hold our results:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_vecadd.py
    :language: python
    :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
    :start-after: ex_vecadd.allocate.begin
@@ -57,7 +57,7 @@ an appropriate launch configuration with a 1D grid (see
 :ref:`cuda-kernel-invocation`) for a given data size and is often the simplest
 way of launching a kernel:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_vecadd.py
    :language: python
    :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
    :start-after: ex_vecadd.forall.begin
@@ -75,7 +75,7 @@ One can also configure the grid manually using the subscripting syntax. The
 following example launches a grid with sufficient threads to operate on every
 vector element:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_vecadd.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_vecadd.py
    :language: python
    :caption: from ``test_ex_vecadd`` in ``numba/cuda/tests/doc_examples/test_vecadd.py``
    :start-after: ex_vecadd.launch.begin
@@ -113,7 +113,7 @@ we have a one dimensional object which we'll represent with an array of values. 
 of the element in the array is the position of a point within the object, and the value
 of the element represents the temperature. 
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_laplace.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_laplace.py
    :language: python
    :caption: from ``test_ex_laplace`` in ``numba/cuda/tests/doc_examples/test_laplace.py``
    :start-after: ex_laplace.import.begin
@@ -124,7 +124,7 @@ of the element represents the temperature.
 
 Some initial setup here. Let's make one point in the center of the object very hot.
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_laplace.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_laplace.py
    :language: python
    :caption: from ``test_ex_laplace`` in ``numba/cuda/tests/doc_examples/test_laplace.py``
    :start-after: ex_laplace.allocate.begin
@@ -141,7 +141,7 @@ in a loop over the desired number of timesteps. The kernel is below. Note the us
 synchronization and the use of two buffers swapped at each iteration to avoid race conditions. See 
 :func:`numba.cuda.cg.this_grid() <numba.cuda.cg.this_grid>` for details.
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_laplace.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_laplace.py
    :language: python
    :caption: from ``test_ex_laplace`` in ``numba/cuda/tests/doc_examples/test_laplace.py``
    :start-after: ex_laplace.kernel.begin
@@ -152,7 +152,7 @@ synchronization and the use of two buffers swapped at each iteration to avoid ra
 
 Calling the kernel:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_laplace.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_laplace.py
    :language: python
    :caption: from ``test_ex_laplace`` in ``numba/cuda/tests/doc_examples/test_laplace.py``
    :start-after: ex_laplace.launch.begin
@@ -181,7 +181,7 @@ using a successively smaller number of threads.
 Note that this is a fairly naive implementation, and there are more efficient ways of implementing reductions
 using Numba - see :ref:`cuda_montecarlo` for an example.
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_reduction.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_reduction.py
    :language: python
    :caption: from ``test_ex_reduction`` in ``numba/cuda/tests/doc_examples/test_reduction.py``
    :start-after: ex_reduction.import.begin
@@ -192,7 +192,7 @@ using Numba - see :ref:`cuda_montecarlo` for an example.
 Let's create some one dimensional data that we'll use to demonstrate the
 kernel itself:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_reduction.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_reduction.py
    :language: python
    :caption: from ``test_ex_reduction`` in ``numba/cuda/tests/doc_examples/test_reduction.py``
    :start-after: ex_reduction.allocate.begin
@@ -203,7 +203,7 @@ kernel itself:
 
 Here is a version of the kernel implemented using Numba:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_reduction.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_reduction.py
    :language: python
    :caption: from ``test_ex_reduction`` in ``numba/cuda/tests/doc_examples/test_reduction.py``
    :start-after: ex_reduction.kernel.begin
@@ -214,7 +214,7 @@ Here is a version of the kernel implemented using Numba:
 We can run kernel and verify that the same result is obtained through
 summing data on the host as follows:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_reduction.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_reduction.py
    :language: python
    :caption: from ``test_ex_reduction`` in ``numba/cuda/tests/doc_examples/test_reduction.py``
    :start-after: ex_reduction.launch.begin
@@ -249,7 +249,7 @@ Our goal will be to create a new column called ``session_id``, which contains a 
 session. We'll define the boundary between sessions as when there has been at least one hour between clicks.
 
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_sessionize.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_sessionize.py
    :language: python
    :caption: from ``test_ex_sessionize`` in ``numba/cuda/tests/doc_examples/test_sessionize.py``
    :start-after: ex_sessionize.import.begin
@@ -259,7 +259,7 @@ session. We'll define the boundary between sessions as when there has been at le
    
 Here is a solution using Numba:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_sessionize.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_sessionize.py
    :language: python
    :caption: from ``test_ex_sessionize`` in ``numba/cuda/tests/doc_examples/test_sessionize.py``
    :start-after: ex_sessionize.kernel.begin
@@ -269,7 +269,7 @@ Here is a solution using Numba:
 
 Let's generate some data and try out the kernel:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_sessionize.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_sessionize.py
    :language: python
    :caption: from ``test_ex_sessionize`` in ``numba/cuda/tests/doc_examples/test_sessionize.py``
    :start-after: ex_sessionize.allocate.begin
@@ -291,7 +291,7 @@ they can directly reuse potential business logic with fewer code changes.
 
 Take the following example function:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
    :language: python
    :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
    :start-after: ex_cpu_gpu_compat.define.begin
@@ -301,7 +301,7 @@ Take the following example function:
 
 The function ``business_logic`` can be run standalone in compiled form on the CPU:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
    :language: python
    :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
    :start-after: ex_cpu_gpu_compat.cpurun.begin
@@ -312,7 +312,7 @@ The function ``business_logic`` can be run standalone in compiled form on the CP
 It can also be directly reused threadwise inside a GPU kernel. For example one may 
 generate some vectors to represent ``x``, ``y``, and ``z``:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
    :language: python
    :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
    :start-after: ex_cpu_gpu_compat.allocate.begin
@@ -322,7 +322,7 @@ generate some vectors to represent ``x``, ``y``, and ``z``:
 
 And a numba kernel referencing the decorated function:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
    :language: python
    :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
    :start-after: ex_cpu_gpu_compat.usegpu.begin
@@ -332,7 +332,7 @@ And a numba kernel referencing the decorated function:
 
 This kernel can be invoked in the normal way:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py
    :language: python
    :caption: from ``test_ex_cpu_gpu_compat`` in ``numba/cuda/tests/doc_examples/test_cpu_gpu_compat.py``
    :start-after: ex_cpu_gpu_compat.launch.begin
@@ -353,7 +353,7 @@ under the curve is approximated by taking the average of many rectangles formed 
 In addition, this example shows how to perform reductions in numba using the 
 :func:`cuda.reduce() <numba.cuda.Reduce>` API.
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_montecarlo.py
    :language: python
    :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
    :start-after: ex_montecarlo.import.begin
@@ -363,7 +363,7 @@ In addition, this example shows how to perform reductions in numba using the
 
 Let's create a variable to control the number of samples drawn:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_montecarlo.py
    :language: python
    :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
    :start-after: ex_montecarlo.define.begin
@@ -374,7 +374,7 @@ Let's create a variable to control the number of samples drawn:
 
 The following kernel implements the main integration routine:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_montecarlo.py
    :language: python
    :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
    :start-after: ex_montecarlo.kernel.begin
@@ -386,7 +386,7 @@ This convenience function calls the kernel performs some
 preprocessing and post processing steps. Note the use of Numba's reduction API to
 take sum of the array and compute the final result:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_montecarlo.py
    :language: python
    :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
    :start-after: ex_montecarlo.callfunc.begin
@@ -398,7 +398,7 @@ take sum of the array and compute the final result:
 We can now use ``mc_integrate`` to compute the definite integral of this function between
 two limits:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_montecarlo.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_montecarlo.py
    :language: python
    :caption: from ``test_ex_montecarlo`` in ``numba/cuda/tests/doc_examples/test_montecarlo.py``
    :start-after: ex_montecarlo.launch.begin
@@ -413,7 +413,7 @@ Matrix multiplication
 =====================
 First, import the modules needed for this example:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_matmul.py
    :language: python
    :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
    :start-after: magictoken.ex_import.begin
@@ -423,7 +423,7 @@ First, import the modules needed for this example:
 
 Here is a naïve implementation of matrix multiplication using a CUDA kernel:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_matmul.py
    :language: python
    :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
    :start-after: magictoken.ex_matmul.begin
@@ -433,7 +433,7 @@ Here is a naïve implementation of matrix multiplication using a CUDA kernel:
 
 An example usage of this function is as follows:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_matmul.py
    :language: python
    :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
    :start-after: magictoken.ex_run_matmul.begin
@@ -452,7 +452,7 @@ for threads in a block to cooperatively compute on a task.  The following
 implements a faster version of the square matrix multiplication using shared
 memory:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_matmul.py
    :language: python
    :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
    :start-after: magictoken.ex_fast_matmul.begin
@@ -471,7 +471,7 @@ in the next loop iteration.
 
 An example usage of the ``fast_matmul`` function is as follows:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_matmul.py
    :language: python
    :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
    :start-after: magictoken.ex_run_fast_matmul.begin
@@ -502,7 +502,7 @@ follows by adjusting the ``blockspergrid`` variable:
 
 Again, here is an example usage:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_matmul.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_matmul.py
    :language: python
    :caption: from ``test_ex_matmul`` in ``numba/cuda/tests/doc_examples/test_matmul.py``
    :start-after: magictoken.ex_run_nonsquare.begin
@@ -537,7 +537,7 @@ called inside kernels, but the output array must be passed in as a positional
 argument. The following example demonstrates a call to :func:`np.sin` inside a
 kernel following this pattern:
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_ufunc.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_ufunc.py
    :language: python
    :caption: from ``test_ex_cuda_ufunc_call`` in ``numba/cuda/tests/doc_examples/test_ufunc.py``
    :start-after: ex_cuda_ufunc.begin

--- a/docs/source/user/external-memory.rst
+++ b/docs/source/user/external-memory.rst
@@ -1,0 +1,320 @@
+.. _cuda-emm-plugin:
+
+=================================================
+External Memory Management (EMM) Plugin interface
+=================================================
+
+The :ref:`CUDA Array Interface <cuda-array-interface>` enables sharing of data
+between different Python libraries that access CUDA devices. However, each
+library manages its own memory distinctly from the others. For example:
+
+- By default, Numba allocates memory on CUDA devices by interacting with the
+  CUDA driver API to call functions such as ``cuMemAlloc`` and ``cuMemFree``,
+  which is suitable for many use cases.
+- The RAPIDS libraries (cuDF, cuML, etc.) use the `RAPIDS Memory Manager (RMM)
+  <https://github.com/rapidsai/rmm>`_ for allocating device memory.
+- `CuPy <https://cupy.chainer.org/>`_ includes a `memory pool implementation
+  <https://docs-cupy.chainer.org/en/stable/reference/memory.html>`_ for both
+  device and pinned memory.
+
+When multiple CUDA-aware libraries are used together, it may be preferable for
+Numba to defer to another library for memory management. The EMM Plugin
+interface facilitates this, by enabling Numba to use another CUDA-aware library
+for all allocations and deallocations.
+
+An EMM Plugin is used to facilitate the use of an external library for memory
+management. An EMM Plugin can be a part of an external library, or could be
+implemented as a separate library.
+
+
+Overview of External Memory Management
+======================================
+
+When an EMM Plugin is in use (see :ref:`setting-emm-plugin`), Numba will make
+memory allocations and deallocations through the Plugin. It will never directly call
+functions such as ``cuMemAlloc``, ``cuMemFree``, etc.
+
+EMM Plugins always take responsibility for the management of device memory.
+However, not all CUDA-aware libraries also support managing host memory, so a
+facility for Numba to continue the management of host memory whilst ceding
+control of device memory to the EMM is provided (see
+:ref:`host-only-cuda-memory-manager`).
+
+
+Effects on Deallocation Strategies
+----------------------------------
+
+Numba's internal :ref:`deallocation-behavior` is designed to increase efficiency
+by deferring deallocations until a significant quantity are pending. It also
+provides a mechanism for preventing deallocations entirely during critical
+sections, using the :func:`~numba.cuda.defer_cleanup` context manager.
+
+When an EMM Plugin is in use, the deallocation strategy is implemented by the
+EMM, and Numba's internal deallocation mechanism is not used. The EMM
+Plugin could implement:
+  
+- A similar strategy to the Numba deallocation behaviour, or
+- Something more appropriate to the plugin - for example, deallocated memory
+  might immediately be returned to a memory pool.
+
+The ``defer_cleanup`` context manager may behave differently with an EMM Plugin
+- an EMM Plugin should be accompanied by documentation of the behaviour of the
+``defer_cleanup`` context manager when it is in use. For example, a pool
+allocator could always immediately return memory to a pool even when the
+context manager is in use, but could choose not to free empty pools until
+``defer_cleanup`` is not in use.
+
+
+Management of other objects
+---------------------------
+
+In addition to memory, Numba manages the allocation and deallocation of
+:ref:`events <events>`, :ref:`streams <streams>`, and modules (a module is a
+compiled object, which is generated from ``@cuda.jit``\ -ted functions). The
+management of events, streams, and modules is unchanged by the use of an EMM
+Plugin.
+
+
+Asynchronous allocation and deallocation
+----------------------------------------
+
+The present EMM Plugin interface does not provide support for asynchronous
+allocation and deallocation. This may be added to a future version of the
+interface.
+
+
+Implementing an EMM Plugin
+==========================
+
+An EMM Plugin is implemented by deriving from
+:class:`~numba.cuda.BaseCUDAMemoryManager`. A summary of considerations for the
+implementation follows:
+
+- Numba instantiates one instance of the EMM Plugin class per context. The
+  context that owns an EMM Plugin object is accessible through ``self.context``,
+  if required.
+- The EMM Plugin is transparent to any code that uses Numba - all its methods
+  are invoked by Numba, and never need to be called by code that uses Numba.
+- The allocation methods ``memalloc``, ``memhostalloc``, and ``mempin``, should
+  use the underlying library to allocate and/or pin device or host memory, and
+  construct an instance of a :ref:`memory pointer <memory-pointers>`
+  representing the memory to return back to Numba. These methods are always
+  called when the current CUDA context is the context that owns the EMM Plugin
+  instance.
+- The ``initialize`` method is called by Numba prior to the first use of the EMM
+  Plugin object for a context. This method should do anything required to
+  prepare the underlying library for allocations in the current context. This
+  method may be called multiple times, and must not invalidate previous state
+  when it is called.
+- The ``reset`` method is called when all allocations in the context are to be
+  cleaned up. It may be called even prior to ``initialize``, and an EMM Plugin
+  implementation needs to guard against this.
+- To support inter-GPU communication, the ``get_ipc_handle`` method should
+  provide an :class:`~numba.cuda.IpcHandle` for a given
+  :class:`~numba.cuda.MemoryPointer` instance. This method is part of the EMM
+  interface (rather than being handled within Numba) because the base address of
+  the allocation is only known by the underlying library. Closing an IPC handle
+  is handled internally within Numba.
+- It is optional to provide memory info from the ``get_memory_info`` method, which
+  provides a count of the total and free memory on the device for the context.
+  It is preferable to implement the method, but this may not be practical for
+  all allocators. If memory info is not provided, this method should raise a
+  :class:`RuntimeError`.
+- The ``defer_cleanup`` method should return a context manager that ensures that
+  expensive cleanup operations are avoided whilst it is active. The nuances of
+  this will vary between plugins, so the plugin documentation should include an
+  explanation of how deferring cleanup affects deallocations, and performance in
+  general.
+- The ``interface_version`` property is used to ensure that the plugin version
+  matches the interface provided by the version of Numba. At present, this
+  should always be 1.
+
+Full documentation for the base class follows:
+
+.. autoclass:: numba.cuda.BaseCUDAMemoryManager
+   :members: memalloc, memhostalloc, mempin, initialize, get_ipc_handle,
+             get_memory_info, reset, defer_cleanup, interface_version
+   :member-order: bysource
+
+
+.. _host-only-cuda-memory-manager:
+
+The Host-Only CUDA Memory Manager
+---------------------------------
+
+Some external memory managers will support management of on-device memory but
+not host memory. For implementing EMM Plugins using one of these memory
+managers, a partial implementation of a plugin that implements host-side
+allocation and pinning is provided. To use it, derive from
+:class:`~numba.cuda.HostOnlyCUDAMemoryManager` instead of
+:class:`~numba.cuda.BaseCUDAMemoryManager`. Guidelines for using this class
+are:
+
+- The host-only memory manager implements ``memhostalloc`` and ``mempin`` - the
+  EMM Plugin should still implement ``memalloc``.
+- If ``reset`` is overridden, it must also call ``super().reset()`` to allow the
+  host allocations to be cleaned up.
+- If ``defer_cleanup`` is overridden, it must hold an active context manager
+  from ``super().defer_cleanup()`` to ensure that host-side cleanup is also
+  deferred.
+
+Documentation for the methods of :class:`~numba.cuda.HostOnlyCUDAMemoryManager`
+follows:
+
+.. autoclass:: numba.cuda.HostOnlyCUDAMemoryManager
+   :members: memhostalloc, mempin, reset, defer_cleanup
+   :member-order: bysource
+
+
+The IPC Handle Mixin
+--------------------
+
+An implementation of the ``get_ipc_handle()`` function is is provided in the
+``GetIpcHandleMixin`` class. This uses the driver API to determine the base
+address of an allocation for opening an IPC handle. If this implementation is
+appropriate for an EMM plugin, it can be added by mixing in the
+``GetIpcHandleMixin`` class:
+
+.. autoclass:: numba.cuda.GetIpcHandleMixin
+   :members: get_ipc_handle
+
+
+Classes and structures of returned objects
+==========================================
+
+This section provides an overview of the classes and structures that need to be
+constructed by an EMM Plugin.
+
+.. _memory-pointers:
+
+Memory Pointers
+---------------
+
+EMM Plugins should construct memory pointer instances that represent their
+allocations, for return to Numba. The appropriate memory pointer class to use in
+each method is:
+
+- :class:`~numba.cuda.MemoryPointer`: returned from ``memalloc``
+- :class:`~numba.cuda.MappedMemory`: returned from ``memhostalloc`` or
+  ``mempin`` when the host memory is mapped into the device memory space.
+- :class:`~numba.cuda.PinnedMemory`: return from ``memhostalloc`` or ``mempin``
+  when the host memory is not mapped into the device memory space.
+
+Memory pointers can take a finalizer, which is a function that is called when
+the buffer is no longer needed. Usually the finalizer will make a call to the
+memory management library (either internal to Numba, or external if allocated
+by an EMM Plugin) to inform it that the memory is no longer required, and that
+it could potentially be freed and/or unpinned. The memory manager may choose to
+defer actually cleaning up the memory to any later time after the finalizer
+runs - it is not required to free the buffer immediately.
+
+Documentation for the memory pointer classes follows.
+
+.. autoclass:: numba.cuda.MemoryPointer
+
+The ``AutoFreePointer`` class need not be used directly, but is documented here
+as it is subclassed by :class:`numba.cuda.MappedMemory`:
+
+.. autoclass:: numba.cuda.cudadrv.driver.AutoFreePointer
+
+.. autoclass:: numba.cuda.MappedMemory
+
+.. autoclass:: numba.cuda.PinnedMemory
+
+
+Memory Info
+-----------
+
+If an implementation of
+:meth:`~numba.cuda.BaseCUDAMemoryManager.get_memory_info` is to provide a
+result, then it should return an instance of the ``MemoryInfo`` named tuple:
+
+.. autoclass:: numba.cuda.MemoryInfo
+
+
+IPC
+---
+
+An instance of ``IpcHandle`` is required to be returned from an implementation
+of :meth:`~numba.cuda.BaseCUDAMemoryManager.get_ipc_handle`:
+
+.. autoclass:: numba.cuda.IpcHandle
+
+Guidance for constructing an IPC handle in the context of implementing an EMM
+Plugin:
+
+- The ``memory`` parameter passed to the ``get_ipc_handle`` method of an EMM
+  Plugin can be passed as the ``base`` parameter.
+- A suitable type for the ``handle`` can be constructed as ``ctypes.c_byte *
+  64``. The data for ``handle`` must be populated using a method for obtaining a
+  CUDA IPC handle appropriate to the underlying library.
+- ``size`` should match the size of the original allocation, which can be
+  obtained with ``memory.size`` in ``get_ipc_handle``.
+- An appropriate value for ``source_info`` can be created by calling
+  ``self.context.device.get_device_identity()``.
+- If the underlying memory does not point to the base of an allocation returned
+  by the CUDA driver or runtime API (e.g. if a pool allocator is in use) then
+  the ``offset`` from the base must be provided.
+
+
+.. _setting-emm-plugin:
+
+Setting the EMM Plugin
+======================
+
+By default, Numba uses its internal memory management - if an EMM Plugin is to
+be used, it must be configured. There are two mechanisms for configuring the use
+of an EMM Plugin: an environment variable, and a function.
+
+
+Environment variable
+--------------------
+
+A module name can be provided in the environment variable,
+``NUMBA_CUDA_MEMORY_MANAGER``. If this environment variable is set, Numba will
+attempt to import the module, and and use its ``_numba_memory_manager`` global
+variable as the memory manager class. This is primarily useful for running the
+Numba test suite with an EMM Plugin, e.g.:
+
+.. code::
+
+   $ NUMBA_CUDA_MEMORY_MANAGER=rmm python -m numba.runtests numba.cuda.tests
+
+
+Function
+--------
+
+The :func:`~numba.cuda.set_memory_manager` function can be used to set the
+memory manager at runtime. This should be called prior to the initialization of
+any contexts, as EMM Plugin instances are instantiated along with contexts.
+
+.. autofunction:: numba.cuda.set_memory_manager
+
+
+Resetting the memory manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is recommended that the memory manager is set once prior to using any CUDA
+functionality, and left unchanged for the remainder of execution. It is possible
+to set the memory manager multiple times, noting the following:
+
+* At the time of their creation, contexts are bound to an instance of a memory
+  manager for their lifetime.
+* Changing the memory manager will have no effect on existing contexts - only
+  contexts created after the memory manager was updated will use instances of
+  the new memory manager.
+* :func:`numba.cuda.close` can be used to destroy contexts after setting the
+  memory manager so that they get re-created with the new memory manager.
+
+  - This will invalidate any arrays, streams, events, and modules owned by the
+    context.
+  - Attempting to use invalid arrays, streams, or events will likely fail with
+    an exception being raised due to a ``CUDA_ERROR_INVALID_CONTEXT`` or
+    ``CUDA_ERROR_CONTEXT_IS_DESTROYED`` return code from a Driver API function.
+  - Attempting to use an invalid module will result in similar, or in some
+    cases a segmentation fault / access violation.
+
+.. note:: The invalidation of modules means that all functions compiled with
+          ``@cuda.jit`` prior to context destruction will need to be
+          redefined, as the code underlying them will also have been unloaded
+          from the GPU.

--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -1,0 +1,20 @@
+
+.. _cudafaq:
+
+=================================================
+CUDA Frequently Asked Questions
+=================================================
+
+nvprof reports "No kernels were profiled"
+-----------------------------------------
+
+When using the ``nvprof`` tool to profile Numba jitted code for the CUDA
+target, the output contains ``No kernels were profiled`` but there are clearly
+running kernels present, what is going on?
+
+This is quite likely due to the profiling data not being flushed on program
+exit, see the `NVIDIA CUDA documentation
+<http://docs.nvidia.com/cuda/profiler-users-guide/#flush-profile-data>`_ for
+details. To fix this simply add a call to ``numba.cuda.profile_stop()`` prior
+to the exit point in your program (or wherever you want to stop profiling).
+For more on CUDA profiling support in Numba, see :ref:`cuda-profiling`.

--- a/docs/source/user/fastmath.rst
+++ b/docs/source/user/fastmath.rst
@@ -1,0 +1,36 @@
+
+.. _cuda-fast-math:
+
+CUDA Fast Math
+==============
+
+As noted in :ref:`fast-math`, for certain classes of applications that utilize
+floating point, strict IEEE-754 conformance is not required. For this subset of
+applications, performance speedups may be possible.
+
+The CUDA target implements :ref:`fast-math` behavior with two differences.
+
+* First, the ``fastmath`` argument to the :func:`@jit decorator
+  <numba.cuda.jit>` is limited to the values ``True`` and ``False``.
+  When ``True``, the following optimizations are enabled:
+
+  - Flushing of denormals to zero.
+  - Use of a fast approximation to the square root function.
+  - Use of a fast approximation to the division operation.
+  - Contraction of multiply and add operations into single fused multiply-add
+    operations.
+
+  See the `documentation for nvvmCompileProgram <https://docs.nvidia.com/cuda/libnvvm-api/group__compilation.html#group__compilation_1g76ac1e23f5d0e2240e78be0e63450346>`_ for more details of these optimizations.
+
+* Secondly, calls to a subset of math module functions on ``float32`` operands
+  will be implemented using fast approximate implementations from the libdevice
+  library.
+
+  - :func:`math.cos`: Implemented using `__nv_fast_cosf <https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_fast_cosf.html>`_.
+  - :func:`math.sin`: Implemented using `__nv_fast_sinf <https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_fast_sinf.html>`_.
+  - :func:`math.tan`: Implemented using `__nv_fast_tanf <https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_fast_tanf.html>`_.
+  - :func:`math.exp`: Implemented using `__nv_fast_expf <https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_fast_expf.html>`_.
+  - :func:`math.log2`: Implemented using `__nv_fast_log2f <https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_fast_log2f.html>`_.
+  - :func:`math.log10`: Implemented using `__nv_fast_log10f <https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_fast_log10f.html>`_.
+  - :func:`math.log`: Implemented using `__nv_fast_logf <https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_fast_logf.html>`_.
+  - :func:`math.pow`: Implemented using `__nv_fast_powf <https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_fast_powf.html>`_.

--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -1,0 +1,31 @@
+
+.. _cuda-index:
+
+Numba for CUDA GPUs
+===================
+
+.. toctree::
+
+   overview.rst
+   kernels.rst
+   memory.rst
+   device-functions.rst
+   cudapysupported.rst
+   fastmath.rst
+   intrinsics.rst
+   cooperative_groups.rst
+   random.rst
+   device-management.rst
+   examples.rst
+   simulator.rst
+   reduction.rst
+   ufunc.rst
+   ipc.rst
+   cuda_array_interface.rst
+   external-memory.rst
+   bindings.rst
+   cuda_ffi.rst
+   cuda_compilation.rst
+   caching.rst
+   minor_version_compatibility.rst
+   faq.rst

--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -1,8 +1,8 @@
 
 .. _cuda-index:
 
-Numba for CUDA GPUs
-===================
+User guide
+==========
 
 .. toctree::
 

--- a/docs/source/user/intrinsics.rst
+++ b/docs/source/user/intrinsics.rst
@@ -1,0 +1,58 @@
+
+Supported Atomic Operations
+===========================
+
+Numba provides access to some of the atomic operations supported in CUDA. Those
+that are presently implemented are as follows:
+
+.. automodule:: numba.cuda
+    :members: atomic
+    :noindex:
+
+Example
+'''''''
+
+The following code demonstrates the use of :class:`numba.cuda.atomic.max` to
+find the maximum value in an array. Note that this is not the most efficient way
+of finding a maximum in this case, but that it serves as an example::
+
+    from numba import cuda
+    import numpy as np
+
+    @cuda.jit
+    def max_example(result, values):
+        """Find the maximum value in values and store in result[0]"""
+        tid = cuda.threadIdx.x
+        bid = cuda.blockIdx.x
+        bdim = cuda.blockDim.x
+        i = (bid * bdim) + tid
+        cuda.atomic.max(result, 0, values[i])
+
+
+    arr = np.random.rand(16384)
+    result = np.zeros(1, dtype=np.float64)
+
+    max_example[256,64](result, arr)
+    print(result[0]) # Found using cuda.atomic.max
+    print(max(arr))  # Print max(arr) for comparison (should be equal!)
+
+
+Multiple dimension arrays are supported by using a tuple of ints for the index::
+
+
+    @cuda.jit
+    def max_example_3d(result, values):
+        """
+        Find the maximum value in values and store in result[0].
+        Both result and values are 3d arrays.
+        """
+        i, j, k = cuda.grid(3)
+        # Atomically store to result[0,1,2] from values[i, j, k]
+        cuda.atomic.max(result, (0, 1, 2), values[i, j, k])
+
+    arr = np.random.rand(1000).reshape(10,10,10)
+    result = np.zeros((3, 3, 3), dtype=np.float64)
+    max_example_3d[(2, 2, 2), (5, 5, 5)](result, arr)
+    print(result[0, 1, 2], '==', np.max(arr))
+
+

--- a/docs/source/user/ipc.rst
+++ b/docs/source/user/ipc.rst
@@ -1,0 +1,36 @@
+===================
+Sharing CUDA Memory
+===================
+
+.. _cuda-ipc-memory:
+
+Sharing between process
+=======================
+
+Sharing between processes is implemented using the Legacy CUDA IPC API
+(functions whose names begin with ``cuIpc``), and is supported only on Linux.
+
+
+Export device array to another process
+--------------------------------------
+
+A device array can be shared with another process in the same machine using
+the CUDA IPC API.  To do so, use the ``.get_ipc_handle()`` method on the device
+array to get a ``IpcArrayHandle`` object, which can be transferred to another
+process.
+
+
+.. automethod:: numba.cuda.cudadrv.devicearray.DeviceNDArray.get_ipc_handle
+    :noindex:
+
+.. autoclass:: numba.cuda.cudadrv.devicearray.IpcArrayHandle
+    :members: open, close
+
+
+Import IPC memory from another process
+--------------------------------------
+
+The following function is used to open IPC handle from another process
+as a device array.
+
+.. automethod:: numba.cuda.open_ipc_array

--- a/docs/source/user/kernels.rst
+++ b/docs/source/user/kernels.rst
@@ -1,0 +1,233 @@
+
+====================
+Writing CUDA Kernels
+====================
+
+Introduction
+============
+
+CUDA has an execution model unlike the traditional sequential model used
+for programming CPUs.  In CUDA, the code you write will be executed by
+multiple threads at once (often hundreds or thousands).  Your solution will
+be modeled by defining a thread hierarchy of *grid*, *blocks* and *threads*.
+
+Numba's CUDA support exposes facilities to declare and manage this
+hierarchy of threads.  The facilities are largely similar to those
+exposed by NVidia's CUDA C language.
+
+Numba also exposes three kinds of GPU memory: global :ref:`device memory
+<cuda-device-memory>` (the large, relatively slow
+off-chip memory that's connected to the GPU itself), on-chip
+:ref:`shared memory <cuda-shared-memory>` and :ref:`local memory <cuda-local-memory>`.
+For all but the simplest algorithms, it is important that you carefully
+consider how to use and access memory in order to minimize bandwidth
+requirements and contention.
+
+
+Kernel declaration
+==================
+
+A *kernel function* is a GPU function that is meant to be called from CPU
+code (*).  It gives it two fundamental characteristics:
+
+* kernels cannot explicitly return a value; all result data must be written
+  to an array passed to the function (if computing a scalar, you will
+  probably pass a one-element array);
+
+* kernels explicitly declare their thread hierarchy when called: i.e.
+  the number of thread blocks and the number of threads per block
+  (note that while a kernel is compiled once, it can be called multiple
+  times with different block sizes or grid sizes).
+
+At first sight, writing a CUDA kernel with Numba looks very much like
+writing a :term:`JIT function` for the CPU::
+
+    @cuda.jit
+    def increment_by_one(an_array):
+        """
+        Increment all array elements by one.
+        """
+        # code elided here; read further for different implementations
+
+(*) Note: newer CUDA devices support device-side kernel launching; this feature
+is called *dynamic parallelism* but Numba does not support it currently)
+
+
+.. _cuda-kernel-invocation:
+
+Kernel invocation
+=================
+
+A kernel is typically launched in the following way::
+
+    threadsperblock = 32
+    blockspergrid = (an_array.size + (threadsperblock - 1)) // threadsperblock
+    increment_by_one[blockspergrid, threadsperblock](an_array)
+
+We notice two steps here:
+
+* Instantiate the kernel proper, by specifying a number of blocks
+  (or "blocks per grid"), and a number of threads per block.  The product
+  of the two will give the total number of threads launched.  Kernel
+  instantiation is done by taking the compiled kernel function
+  (here ``increment_by_one``) and indexing it with a tuple of integers.
+
+* Running the kernel, by passing it the input array (and any separate
+  output arrays if necessary). Kernels run asynchronously: launches queue their
+  execution on the device and then return immediately.  You can use
+  :func:`cuda.synchronize() <numba.cuda.synchronize>` to wait for all previous
+  kernel launches to finish executing.
+
+.. note:: Passing an array that resides in host memory will implicitly cause a
+   copy back to the host, which will be synchronous. In this case, the kernel
+   launch will not return until the data is copied back, and therefore appears
+   to execute synchronously.
+
+Choosing the block size
+-----------------------
+
+It might seem curious to have a two-level hierarchy when declaring the
+number of threads needed by a kernel.  The block size (i.e. number of
+threads per block) is often crucial:
+
+* On the software side, the block size determines how many threads
+  share a given area of :ref:`shared memory <cuda-shared-memory>`.
+
+* On the hardware side, the block size must be large enough for full
+  occupation of execution units; recommendations can be found in the
+  `CUDA C Programming Guide`_.
+
+Multi-dimensional blocks and grids
+----------------------------------
+
+To help deal with multi-dimensional arrays, CUDA allows you to specify
+multi-dimensional blocks and grids.  In the example above, you could
+make ``blockspergrid`` and ``threadsperblock`` tuples of one, two
+or three integers.  Compared to 1D declarations of equivalent sizes,
+this doesn't change anything to the efficiency or behaviour of generated
+code, but can help you write your algorithms in a more natural way.
+
+
+Thread positioning
+==================
+
+When running a kernel, the kernel function's code is executed by every
+thread once.  It therefore has to know which thread it is in, in order
+to know which array element(s) it is responsible for (complex algorithms
+may define more complex responsibilities, but the underlying principle
+is the same).
+
+One way is for the thread to determine its position in the grid and block
+and manually compute the corresponding array position::
+
+    @cuda.jit
+    def increment_by_one(an_array):
+        # Thread id in a 1D block
+        tx = cuda.threadIdx.x
+        # Block id in a 1D grid
+        ty = cuda.blockIdx.x
+        # Block width, i.e. number of threads per block
+        bw = cuda.blockDim.x
+        # Compute flattened index inside the array
+        pos = tx + ty * bw
+        if pos < an_array.size:  # Check array boundaries
+            an_array[pos] += 1
+
+.. note:: Unless you are sure the block size and grid size is a divisor
+   of your array size, you **must** check boundaries as shown above.
+
+:attr:`.threadIdx`, :attr:`.blockIdx`, :attr:`.blockDim` and :attr:`.gridDim`
+are special objects provided by the CUDA backend for the sole purpose of
+knowing the geometry of the thread hierarchy and the position of the
+current thread within that geometry.
+
+These objects can be 1D, 2D or 3D, depending on how the kernel was
+:ref:`invoked <cuda-kernel-invocation>`.  To access the value at each
+dimension, use the ``x``, ``y`` and ``z`` attributes of these objects,
+respectively.
+
+.. attribute:: numba.cuda.threadIdx
+   :noindex:
+
+   The thread indices in the current thread block.  For 1D blocks, the index
+   (given by the ``x`` attribute) is an integer spanning the range from 0
+   inclusive to :attr:`numba.cuda.blockDim` exclusive.  A similar rule
+   exists for each dimension when more than one dimension is used.
+
+.. attribute:: numba.cuda.blockDim
+   :noindex:
+
+   The shape of the block of threads, as declared when instantiating the
+   kernel.  This value is the same for all threads in a given kernel, even
+   if they belong to different blocks (i.e. each block is "full").
+
+.. attribute:: numba.cuda.blockIdx
+   :noindex:
+
+   The block indices in the grid of threads launched a kernel.  For a 1D grid,
+   the index (given by the ``x`` attribute) is an integer spanning the range
+   from 0 inclusive to :attr:`numba.cuda.gridDim` exclusive.  A similar rule
+   exists for each dimension when more than one dimension is used.
+
+.. attribute:: numba.cuda.gridDim
+   :noindex:
+
+   The shape of the grid of blocks, i.e. the total number of blocks launched
+   by this kernel invocation, as declared when instantiating the kernel.
+
+Absolute positions
+------------------
+
+Simple algorithms will tend to always use thread indices in the
+same way as shown in the example above.  Numba provides additional facilities
+to automate such calculations:
+
+.. function:: numba.cuda.grid(ndim)
+   :noindex:
+
+   Return the absolute position of the current thread in the entire
+   grid of blocks.  *ndim* should correspond to the number of dimensions
+   declared when instantiating the kernel.  If *ndim* is 1, a single integer
+   is returned.  If *ndim* is 2 or 3, a tuple of the given number of
+   integers is returned.
+
+.. function:: numba.cuda.gridsize(ndim)
+   :noindex:
+
+   Return the absolute size (or shape) in threads of the entire grid of
+   blocks.  *ndim* has the same meaning as in :func:`.grid` above.
+
+With these functions, the incrementation example can become::
+
+    @cuda.jit
+    def increment_by_one(an_array):
+        pos = cuda.grid(1)
+        if pos < an_array.size:
+            an_array[pos] += 1
+
+The same example for a 2D array and grid of threads would be::
+
+    @cuda.jit
+    def increment_a_2D_array(an_array):
+        x, y = cuda.grid(2)
+        if x < an_array.shape[0] and y < an_array.shape[1]:
+           an_array[x, y] += 1
+
+Note the grid computation when instantiating the kernel must still be
+done manually, for example::
+
+    threadsperblock = (16, 16)
+    blockspergrid_x = math.ceil(an_array.shape[0] / threadsperblock[0])
+    blockspergrid_y = math.ceil(an_array.shape[1] / threadsperblock[1])
+    blockspergrid = (blockspergrid_x, blockspergrid_y)
+    increment_a_2D_array[blockspergrid, threadsperblock](an_array)
+
+
+Further Reading
+----------------
+
+Please refer to the the `CUDA C Programming Guide`_ for a detailed discussion
+of CUDA programming.
+
+
+.. _CUDA C Programming Guide: http://docs.nvidia.com/cuda/cuda-c-programming-guide

--- a/docs/source/user/laplace_final.svg
+++ b/docs/source/user/laplace_final.svg
@@ -1,0 +1,1953 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="760.32pt" height="427.68pt" viewBox="0 0 760.32 427.68" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2022-04-18T06:58:19.244680</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.5.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 427.68 
+L 760.32 427.68 
+L 760.32 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 95.04 380.6352 
+L 684.288 380.6352 
+L 684.288 51.3216 
+L 95.04 51.3216 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mdea99e8948" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdea99e8948" x="95.04" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(91.85875 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mdea99e8948" x="212.771868" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 200 -->
+      <g transform="translate(203.228118 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mdea99e8948" x="330.503736" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 400 -->
+      <g transform="translate(320.959986 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mdea99e8948" x="448.235604" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 600 -->
+      <g transform="translate(438.691854 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mdea99e8948" x="565.967473" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 800 -->
+      <g transform="translate(556.423723 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mdea99e8948" x="683.699341" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1000 -->
+      <g transform="translate(670.974341 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- Position -->
+     <g transform="translate(342.95025 419.549575)scale(0.24 -0.24)">
+      <defs>
+       <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-50"/>
+      <use xlink:href="#DejaVuSans-6f" x="56.677734"/>
+      <use xlink:href="#DejaVuSans-73" x="117.859375"/>
+      <use xlink:href="#DejaVuSans-69" x="169.958984"/>
+      <use xlink:href="#DejaVuSans-74" x="197.742188"/>
+      <use xlink:href="#DejaVuSans-69" x="236.951172"/>
+      <use xlink:href="#DejaVuSans-6f" x="264.734375"/>
+      <use xlink:href="#DejaVuSans-6e" x="325.916016"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <defs>
+       <path id="mded8b8a71f" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mded8b8a71f" x="95.04" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(81.6775 384.434419)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mded8b8a71f" x="95.04" y="322.158479" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 10 -->
+      <g transform="translate(75.315 325.957697)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#mded8b8a71f" x="95.04" y="263.681757" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 20 -->
+      <g transform="translate(75.315 267.480976)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mded8b8a71f" x="95.04" y="205.205036" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 30 -->
+      <g transform="translate(75.315 209.004255)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#mded8b8a71f" x="95.04" y="146.728315" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 40 -->
+      <g transform="translate(75.315 150.527533)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mded8b8a71f" x="95.04" y="88.251593" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 50 -->
+      <g transform="translate(75.315 92.050812)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Temperature -->
+     <g transform="translate(66.32375 291.985275)rotate(-90)scale(0.24 -0.24)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-65" x="44.083984"/>
+      <use xlink:href="#DejaVuSans-6d" x="105.607422"/>
+      <use xlink:href="#DejaVuSans-70" x="203.019531"/>
+      <use xlink:href="#DejaVuSans-65" x="266.496094"/>
+      <use xlink:href="#DejaVuSans-72" x="328.019531"/>
+      <use xlink:href="#DejaVuSans-61" x="369.132812"/>
+      <use xlink:href="#DejaVuSans-74" x="430.412109"/>
+      <use xlink:href="#DejaVuSans-75" x="469.621094"/>
+      <use xlink:href="#DejaVuSans-72" x="533"/>
+      <use xlink:href="#DejaVuSans-65" x="571.863281"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_13">
+    <path d="M 95.04 380.6352 
+L 222.779077 380.529075 
+L 235.729582 380.282199 
+L 243.970813 379.915133 
+L 250.446066 379.406046 
+L 255.744 378.766883 
+L 260.453275 377.962709 
+L 264.57389 377.018844 
+L 268.105846 375.978796 
+L 271.637802 374.686465 
+L 274.581099 373.381548 
+L 277.524396 371.835995 
+L 280.467692 370.015621 
+L 283.410989 367.883451 
+L 285.765626 365.921436 
+L 288.120264 363.713694 
+L 290.474901 361.238701 
+L 292.829538 358.474235 
+L 295.184176 355.397908 
+L 297.538813 351.987431 
+L 299.893451 348.220835 
+L 302.248088 344.077154 
+L 304.602725 339.526635 
+L 306.957363 334.561291 
+L 309.312 329.163589 
+L 312.255297 321.78728 
+L 315.198593 313.692617 
+L 318.14189 304.866826 
+L 321.085187 295.305618 
+L 324.028484 285.00832 
+L 327.56044 271.724356 
+L 331.092396 257.491814 
+L 335.213011 239.815134 
+L 339.922286 218.452801 
+L 345.808879 190.573925 
+L 356.404747 140.249826 
+L 360.525363 121.846751 
+L 364.057319 107.108755 
+L 367.000615 95.761174 
+L 369.355253 87.403982 
+L 371.70989 79.767014 
+L 374.064527 72.918457 
+L 375.830505 68.33741 
+L 377.596484 64.262089 
+L 379.362462 60.725229 
+L 381.12844 57.732218 
+L 382.894418 55.297498 
+L 384.071736 53.990912 
+L 385.249055 52.941263 
+L 386.426374 52.151061 
+L 387.603692 51.622212 
+L 388.781011 51.355994 
+L 389.95833 51.353058 
+L 391.135648 51.61342 
+L 392.312967 52.136471 
+L 393.490286 52.920959 
+L 394.667604 53.96499 
+L 395.844923 55.266207 
+L 397.022242 56.828276 
+L 398.78822 59.649475 
+L 400.554198 63.018479 
+L 402.320176 66.917588 
+L 404.086154 71.326333 
+L 406.440791 77.95742 
+L 408.795429 85.392994 
+L 411.150066 93.566486 
+L 414.093363 104.71072 
+L 417.036659 116.760021 
+L 420.568615 132.184312 
+L 425.27789 153.916868 
+L 434.10778 196.168455 
+L 440.583033 226.545841 
+L 445.292308 247.498702 
+L 449.412923 264.715831 
+L 452.944879 278.497039 
+L 456.476835 291.278339 
+L 459.420132 301.142925 
+L 462.363429 310.276618 
+L 465.306725 318.677631 
+L 468.250022 326.354584 
+L 471.193319 333.324327 
+L 473.547956 338.392009 
+L 475.902593 343.036068 
+L 478.257231 347.278437 
+L 480.611868 351.138941 
+L 482.966505 354.63858 
+L 485.321143 357.799137 
+L 487.67578 360.642848 
+L 490.030418 363.192205 
+L 492.385055 365.456926 
+L 494.739692 367.467195 
+L 497.682989 369.660056 
+L 500.626286 371.534221 
+L 503.569582 373.127028 
+L 506.512879 374.473205 
+L 509.456176 375.604492 
+L 512.988132 376.714066 
+L 516.520088 377.600877 
+L 520.640703 378.406028 
+L 525.349978 379.087343 
+L 530.647912 379.624016 
+L 537.123165 380.047007 
+L 545.364396 380.350594 
+L 557.137582 380.540892 
+L 578.917978 380.625338 
+L 683.699341 380.6352 
+L 683.699341 380.6352 
+" clip-path="url(#p24d58054f1)" style="fill: none; stroke: #000000; stroke-width: 3; stroke-linecap: square"/>
+    <defs>
+     <path id="m7b5e1d1292" d="M 0 -3 
+L -0.673542 -0.927051 
+L -2.85317 -0.927051 
+L -1.089814 0.354102 
+L -1.763356 2.427051 
+L -0 1.145898 
+L 1.763356 2.427051 
+L 1.089814 0.354102 
+L 2.85317 -0.927051 
+L 0.673542 -0.927051 
+z
+" style="stroke: #000000; stroke-linejoin: bevel"/>
+    </defs>
+    <g clip-path="url(#p24d58054f1)">
+     <use xlink:href="#m7b5e1d1292" x="95.04" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="95.628659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="96.217319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="96.805978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="97.394637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="97.983297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="98.571956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="99.160615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="99.749275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="100.337934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="100.926593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="101.515253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="102.103912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="102.692571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="103.281231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="103.86989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="104.458549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="105.047209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="105.635868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="106.224527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="106.813187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="107.401846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="107.990505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="108.579165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="109.167824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="109.756484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="110.345143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="110.933802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="111.522462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="112.111121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="112.69978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="113.28844" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="113.877099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="114.465758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="115.054418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="115.643077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="116.231736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="116.820396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="117.409055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="117.997714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="118.586374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="119.175033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="119.763692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="120.352352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="120.941011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="121.52967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="122.11833" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="122.706989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="123.295648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="123.884308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="124.472967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="125.061626" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="125.650286" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="126.238945" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="126.827604" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="127.416264" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="128.004923" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="128.593582" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="129.182242" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="129.770901" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="130.35956" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="130.94822" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="131.536879" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="132.125538" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="132.714198" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="133.302857" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="133.891516" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="134.480176" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="135.068835" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="135.657495" y="380.635197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="136.246154" y="380.635197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="136.834813" y="380.635197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="137.423473" y="380.635197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="138.012132" y="380.635196" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="138.600791" y="380.635196" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="139.189451" y="380.635196" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="139.77811" y="380.635195" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="140.366769" y="380.635195" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="140.955429" y="380.635194" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="141.544088" y="380.635194" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="142.132747" y="380.635193" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="142.721407" y="380.635193" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="143.310066" y="380.635192" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="143.898725" y="380.635191" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="144.487385" y="380.635191" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="145.076044" y="380.63519" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="145.664703" y="380.635189" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="146.253363" y="380.635188" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="146.842022" y="380.635187" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="147.430681" y="380.635186" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="148.019341" y="380.635184" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="148.608" y="380.635183" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="149.196659" y="380.635182" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="149.785319" y="380.63518" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="150.373978" y="380.635178" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="150.962637" y="380.635177" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="151.551297" y="380.635175" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="152.139956" y="380.635172" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="152.728615" y="380.63517" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="153.317275" y="380.635168" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="153.905934" y="380.635165" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="154.494593" y="380.635162" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="155.083253" y="380.635159" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="155.671912" y="380.635155" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="156.260571" y="380.635152" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="156.849231" y="380.635148" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="157.43789" y="380.635143" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="158.026549" y="380.635139" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="158.615209" y="380.635134" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="159.203868" y="380.635128" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="159.792527" y="380.635123" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="160.381187" y="380.635116" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="160.969846" y="380.63511" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="161.558505" y="380.635102" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="162.147165" y="380.635094" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="162.735824" y="380.635086" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="163.324484" y="380.635077" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="163.913143" y="380.635067" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="164.501802" y="380.635056" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="165.090462" y="380.635045" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="165.679121" y="380.635033" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="166.26778" y="380.635019" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="166.85644" y="380.635005" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="167.445099" y="380.63499" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="168.033758" y="380.634973" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="168.622418" y="380.634956" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="169.211077" y="380.634937" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="169.799736" y="380.634916" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="170.388396" y="380.634894" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="170.977055" y="380.634871" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="171.565714" y="380.634845" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="172.154374" y="380.634818" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="172.743033" y="380.634788" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="173.331692" y="380.634757" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="173.920352" y="380.634723" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="174.509011" y="380.634687" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="175.09767" y="380.634648" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="175.68633" y="380.634606" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="176.274989" y="380.634561" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="176.863648" y="380.634513" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="177.452308" y="380.634462" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="178.040967" y="380.634406" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="178.629626" y="380.634347" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="179.218286" y="380.634284" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="179.806945" y="380.634216" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="180.395604" y="380.634143" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="180.984264" y="380.634065" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="181.572923" y="380.633982" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="182.161582" y="380.633893" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="182.750242" y="380.633798" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="183.338901" y="380.633695" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="183.92756" y="380.633586" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="184.51622" y="380.633469" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="185.104879" y="380.633345" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="185.693538" y="380.633211" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="186.282198" y="380.633068" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="186.870857" y="380.632916" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="187.459516" y="380.632753" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="188.048176" y="380.63258" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="188.636835" y="380.632394" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="189.225495" y="380.632195" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="189.814154" y="380.631982" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="190.402813" y="380.631755" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="190.991473" y="380.631513" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="191.580132" y="380.631255" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="192.168791" y="380.63098" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="192.757451" y="380.630686" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="193.34611" y="380.630373" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="193.934769" y="380.63004" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="194.523429" y="380.629685" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="195.112088" y="380.629306" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="195.700747" y="380.628903" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="196.289407" y="380.628474" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="196.878066" y="380.628018" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="197.466725" y="380.627531" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="198.055385" y="380.627014" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="198.644044" y="380.626464" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="199.232703" y="380.625878" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="199.821363" y="380.625255" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="200.410022" y="380.624593" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="200.998681" y="380.623889" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="201.587341" y="380.623141" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="202.176" y="380.622346" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="202.764659" y="380.621501" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="203.353319" y="380.620604" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="203.941978" y="380.619651" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="204.530637" y="380.618639" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="205.119297" y="380.617565" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="205.707956" y="380.616424" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="206.296615" y="380.615214" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="206.885275" y="380.61393" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="207.473934" y="380.612566" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="208.062593" y="380.611117" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="208.651253" y="380.60958" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="209.239912" y="380.607949" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="209.828571" y="380.606222" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="210.417231" y="380.604392" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="211.00589" y="380.602453" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="211.594549" y="380.6004" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="212.183209" y="380.598227" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="212.771868" y="380.595926" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="213.360527" y="380.593491" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="213.949187" y="380.590915" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="214.537846" y="380.58819" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="215.126505" y="380.585307" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="215.715165" y="380.582259" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="216.303824" y="380.579037" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="216.892484" y="380.575631" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="217.481143" y="380.572031" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="218.069802" y="380.568228" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="218.658462" y="380.56421" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="219.247121" y="380.559967" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="219.83578" y="380.555487" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="220.42444" y="380.550756" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="221.013099" y="380.545764" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="221.601758" y="380.540496" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="222.190418" y="380.534937" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="222.779077" y="380.529075" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="223.367736" y="380.522892" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="223.956396" y="380.516373" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="224.545055" y="380.509501" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="225.133714" y="380.502259" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="225.722374" y="380.494626" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="226.311033" y="380.486591" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="226.899692" y="380.478067" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="227.488352" y="380.4691" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="228.077011" y="380.45966" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="228.66567" y="380.449726" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="229.25433" y="380.439273" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="229.842989" y="380.428279" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="230.431648" y="380.416715" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="231.020308" y="380.404556" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="231.608967" y="380.391773" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="232.197626" y="380.378336" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="232.786286" y="380.364216" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="233.374945" y="380.34938" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="233.963604" y="380.333796" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="234.552264" y="380.317428" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="235.140923" y="380.300242" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="235.729582" y="380.282199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="236.318242" y="380.263262" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="236.906901" y="380.243389" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="237.49556" y="380.22254" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="238.08422" y="380.200671" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="238.672879" y="380.177736" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="239.261538" y="380.15369" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="239.850198" y="380.128484" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="240.438857" y="380.102067" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="241.027516" y="380.07439" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="241.616176" y="380.045396" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="242.204835" y="380.015032" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="242.793495" y="379.983241" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="243.382154" y="379.949961" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="243.970813" y="379.915133" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="244.559473" y="379.8787" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="245.148132" y="379.840587" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="245.736791" y="379.800663" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="246.325451" y="379.758628" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="246.91411" y="379.714616" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="247.502769" y="379.668611" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="248.091429" y="379.62055" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="248.680088" y="379.57035" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="249.268747" y="379.517927" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="249.857407" y="379.463189" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="250.446066" y="379.406046" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="251.034725" y="379.346402" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="251.623385" y="379.28416" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="252.212044" y="379.219219" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="252.800703" y="379.151476" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="253.389363" y="379.080825" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="253.978022" y="379.007154" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="254.566681" y="378.930352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="255.155341" y="378.850302" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="255.744" y="378.766883" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="256.332659" y="378.679972" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="256.921319" y="378.589443" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="257.509978" y="378.495165" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="258.098637" y="378.397003" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="258.687297" y="378.29482" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="259.275956" y="378.188474" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="259.864615" y="378.07782" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="260.453275" y="377.962709" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="261.041934" y="377.842985" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="261.630593" y="377.71849" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="262.219253" y="377.58906" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="262.807912" y="377.45453" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="263.396571" y="377.314746" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="263.985231" y="377.169565" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="264.57389" y="377.018844" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="265.162549" y="376.861033" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="265.751209" y="376.697311" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="266.339868" y="376.527448" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="266.928527" y="376.351219" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="267.517187" y="376.168404" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="268.105846" y="375.978796" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="268.694505" y="375.782187" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="269.283165" y="375.578363" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="269.871824" y="375.367105" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="270.460484" y="375.14819" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="271.049143" y="374.921388" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="271.637802" y="374.686465" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="272.226462" y="374.443184" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="272.815121" y="374.1913" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="273.40378" y="373.930569" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="273.99244" y="373.660737" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="274.581099" y="373.381548" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="275.169758" y="373.092744" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="275.758418" y="372.794057" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="276.347077" y="372.48522" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="276.935736" y="372.165959" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="277.524396" y="371.835995" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="278.113055" y="371.495046" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="278.701714" y="371.142825" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="279.290374" y="370.779044" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="279.879033" y="370.403408" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="280.467692" y="370.015621" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="281.056352" y="369.615385" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="281.645011" y="369.202399" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="282.23367" y="368.776397" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="282.82233" y="368.336997" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="283.410989" y="367.883451" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="283.999648" y="367.415122" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="284.588308" y="366.932002" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="285.176967" y="366.434194" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="285.765626" y="365.921436" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="286.354286" y="365.393349" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="286.942945" y="364.849592" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="287.531604" y="364.289822" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="288.120264" y="363.713694" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="288.708923" y="363.120865" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="289.297582" y="362.510987" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="289.886242" y="361.883715" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="290.474901" y="361.238701" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="291.06356" y="360.575595" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="291.65222" y="359.894049" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="292.240879" y="359.193713" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="292.829538" y="358.474235" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="293.418198" y="357.735265" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="294.006857" y="356.976453" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="294.595516" y="356.197451" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="295.184176" y="355.397908" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="295.772835" y="354.577479" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="296.361495" y="353.735819" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="296.950154" y="352.872583" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="297.538813" y="351.987431" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="298.127473" y="351.080018" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="298.716132" y="350.150006" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="299.304791" y="349.197056" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="299.893451" y="348.220835" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="300.48211" y="347.22101" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="301.070769" y="346.197621" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="301.659429" y="345.149753" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="302.248088" y="344.077154" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="302.836747" y="342.976741" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="303.425407" y="341.852318" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="304.014066" y="340.702326" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="304.602725" y="339.526635" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="305.191385" y="338.324968" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="305.780044" y="337.097031" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="306.368703" y="335.842556" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="306.957363" y="334.561291" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="307.546022" y="333.252993" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="308.134681" y="331.917426" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="308.723341" y="330.554364" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="309.312" y="329.163589" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="309.900659" y="327.744898" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="310.489319" y="326.298097" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="311.077978" y="324.823005" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="311.666637" y="323.319451" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="312.255297" y="321.78728" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="312.843956" y="320.226348" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="313.432615" y="318.636525" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="314.021275" y="317.017695" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="314.609934" y="315.369755" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="315.198593" y="313.692617" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="315.787253" y="311.986204" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="316.375912" y="310.250455" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="316.964571" y="308.485326" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="317.553231" y="306.690786" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="318.14189" y="304.866826" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="318.730549" y="303.013449" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="319.319209" y="301.130689" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="319.907868" y="299.218588" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="320.496527" y="297.27702" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="321.085187" y="295.305618" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="321.673846" y="293.304238" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="322.262505" y="291.273326" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="322.851165" y="289.213507" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="323.439824" y="287.125119" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="324.028484" y="285.00832" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="324.617143" y="282.863303" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="325.205802" y="280.690313" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="325.794462" y="278.489622" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="326.383121" y="276.26152" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="326.97178" y="274.006321" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="327.56044" y="271.724356" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="328.149099" y="269.415978" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="328.737758" y="267.081562" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="329.326418" y="264.721504" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="329.915077" y="262.336227" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="330.503736" y="259.926175" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="331.092396" y="257.491814" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="331.681055" y="255.033639" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="332.269714" y="252.552166" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="332.858374" y="250.047935" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="333.447033" y="247.521514" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="334.035692" y="244.973492" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="334.624352" y="242.404485" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="335.213011" y="239.815134" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="335.80167" y="237.206103" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="336.39033" y="234.57808" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="336.978989" y="231.931775" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="337.567648" y="229.267917" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="338.156308" y="226.587251" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="338.744967" y="223.890552" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="339.333626" y="221.178725" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="339.922286" y="218.452801" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="340.510945" y="215.710209" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="341.099604" y="212.955256" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="341.688264" y="210.188644" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="342.276923" y="207.4112" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="342.865582" y="204.62388" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="343.454242" y="201.827662" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="344.042901" y="199.02354" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="344.63156" y="196.212522" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="345.22022" y="193.395635" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="345.808879" y="190.573925" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="346.397538" y="187.748455" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="346.986198" y="184.920308" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="347.574857" y="182.090586" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="348.163516" y="179.260406" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="348.752176" y="176.430903" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="349.340835" y="173.603227" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="349.929495" y="170.778542" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="350.518154" y="167.958026" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="351.106813" y="165.142873" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="351.695473" y="162.334287" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="352.284132" y="159.533484" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="352.872791" y="156.74169" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="353.461451" y="153.960143" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="354.05011" y="151.190087" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="354.638769" y="148.432772" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="355.227429" y="145.689452" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="355.816088" y="142.961381" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="356.404747" y="140.249826" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="356.993407" y="137.556082" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="357.582066" y="134.881526" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="358.170725" y="132.227646" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="358.759385" y="129.594563" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="359.348044" y="126.987828" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="359.936703" y="124.404411" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="360.525363" y="121.846751" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="361.114022" y="119.315961" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="361.702681" y="116.813261" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="362.291341" y="114.33992" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="362.88" y="111.897212" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="363.468659" y="109.486404" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="364.057319" y="107.108755" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="364.645978" y="104.765513" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="365.234637" y="102.457914" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="365.823297" y="100.187186" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="366.411956" y="97.954539" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="367.000615" y="95.761174" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="367.589275" y="93.608275" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="368.177934" y="91.497012" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="368.766593" y="89.428536" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="369.355253" y="87.403982" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="369.943912" y="85.424467" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="370.532571" y="83.491086" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="371.121231" y="81.604917" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="371.70989" y="79.767014" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="372.298549" y="77.978415" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="372.887209" y="76.240133" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="373.475868" y="74.553157" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="374.064527" y="72.918457" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="374.653187" y="71.336983" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="375.241846" y="69.809702" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="375.830505" y="68.33741" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="376.419165" y="66.921011" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="377.007824" y="65.561731" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="377.596484" y="64.262089" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="378.185143" y="63.023603" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="378.773802" y="61.844703" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="379.362462" y="60.725229" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="379.951121" y="59.666379" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="380.53978" y="58.668544" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="381.12844" y="57.732218" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="381.717099" y="56.857931" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="382.305758" y="56.046199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="382.894418" y="55.297498" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="383.483077" y="54.612267" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="384.071736" y="53.990912" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="384.660396" y="53.433799" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="385.249055" y="52.941263" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="385.837714" y="52.513597" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="386.426374" y="52.151061" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="387.015033" y="51.853873" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="387.603692" y="51.622212" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="388.192352" y="51.456219" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="388.781011" y="51.355994" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="389.36967" y="51.3216" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="389.95833" y="51.353058" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="390.546989" y="51.45035" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="391.135648" y="51.61342" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="391.724308" y="51.842172" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="392.312967" y="52.136471" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="392.901626" y="52.49614" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="393.490286" y="52.920959" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="394.078945" y="53.410669" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="394.667604" y="53.96499" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="395.256264" y="54.583518" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="395.844923" y="55.266207" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="396.433582" y="56.01038" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="397.022242" y="56.828276" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="397.610901" y="57.706704" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="398.19956" y="58.647396" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="398.78822" y="59.649475" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="399.376879" y="60.712435" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="399.965538" y="61.835651" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="400.554198" y="63.018479" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="401.142857" y="64.260234" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="401.731516" y="65.560191" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="402.320176" y="66.917588" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="402.908835" y="68.33163" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="403.497495" y="69.801495" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="404.086154" y="71.326333" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="404.674813" y="72.905264" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="405.263473" y="74.537382" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="405.852132" y="76.221754" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="406.440791" y="77.95742" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="407.029451" y="79.743396" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="407.61811" y="81.578675" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="408.206769" y="83.462225" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="408.795429" y="85.392994" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="409.384088" y="87.369909" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="409.972747" y="89.391875" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="410.561407" y="91.457779" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="411.150066" y="93.566486" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="411.738725" y="95.716843" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="412.327385" y="97.907671" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="412.916044" y="100.137762" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="413.504703" y="102.405852" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="414.093363" y="104.71072" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="414.682022" y="107.051049" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="415.270681" y="109.427081" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="415.859341" y="111.83916" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="416.448" y="114.284395" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="417.036659" y="116.760021" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="417.625319" y="119.264866" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="418.213978" y="121.797687" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="418.802637" y="124.357297" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="419.391297" y="126.942453" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="419.979956" y="129.551886" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="420.568615" y="132.184312" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="421.157275" y="134.838439" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="421.745934" y="137.512977" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="422.334593" y="140.206635" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="422.923253" y="142.918126" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="423.511912" y="145.646168" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="424.100571" y="148.389485" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="424.689231" y="151.146806" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="425.27789" y="153.916868" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="425.866549" y="156.698416" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="426.455209" y="159.490203" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="427.043868" y="162.290992" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="427.632527" y="165.099557" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="428.221187" y="167.914683" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="428.809846" y="170.735168" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="429.398505" y="173.559819" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="429.987165" y="176.38746" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="430.575824" y="179.216923" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="431.164484" y="182.047052" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="431.753143" y="184.876704" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="432.341802" y="187.704746" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="432.930462" y="190.530062" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="433.519121" y="193.351553" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="434.10778" y="196.168455" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="434.69644" y="198.978801" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="435.285099" y="201.782497" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="435.873758" y="204.578244" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="436.462418" y="207.365077" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="437.051077" y="210.142047" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="437.639736" y="212.908222" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="438.228396" y="215.662688" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="438.817055" y="218.404548" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="439.405714" y="221.132926" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="439.994374" y="223.846968" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="440.583033" y="226.545841" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="441.171692" y="229.228736" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="441.760352" y="231.894869" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="442.349011" y="234.543478" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="442.93767" y="237.173825" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="443.52633" y="239.785198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="444.114989" y="242.376908" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="444.703648" y="244.948289" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="445.292308" y="247.498702" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="445.880967" y="250.027529" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="446.469626" y="252.53418" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="447.058286" y="255.018086" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="447.646945" y="257.478706" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="448.235604" y="259.915523" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="448.824264" y="262.328049" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="449.412923" y="264.715831" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="450.001582" y="267.078443" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="450.590242" y="269.415509" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="451.178901" y="271.72674" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="451.76756" y="274.011574" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="452.35622" y="276.268685" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="452.944879" y="278.497039" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="453.533538" y="280.697036" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="454.122198" y="282.869371" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="454.710857" y="285.013975" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="455.299516" y="287.1305" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="455.888176" y="289.218693" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="456.476835" y="291.278339" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="457.065495" y="293.309257" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="457.654154" y="295.311293" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="458.242813" y="297.284318" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="458.831473" y="299.228224" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="459.420132" y="301.142925" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="460.008791" y="303.028353" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="460.597451" y="304.884458" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="461.18611" y="306.71121" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="461.774769" y="308.508595" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="462.363429" y="310.276618" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="462.952088" y="312.015301" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="463.540747" y="313.724681" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="464.129407" y="315.404813" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="464.718066" y="317.055768" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="465.306725" y="318.677631" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="465.895385" y="320.270503" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="466.484044" y="321.834498" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="467.072703" y="323.369748" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="467.661363" y="324.876392" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="468.250022" y="326.354584" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="468.838681" y="327.80449" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="469.427341" y="329.226273" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="470.016" y="330.620141" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="470.604659" y="331.986198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="471.193319" y="333.324327" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="471.781978" y="334.635537" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="472.370637" y="335.913578" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="472.959297" y="337.166" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="473.547956" y="338.392009" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="474.136615" y="339.591721" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="474.725275" y="340.765442" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="475.313934" y="341.913458" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="475.902593" y="343.036068" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="476.491253" y="344.133567" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="477.079912" y="345.206256" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="477.668571" y="346.254442" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="478.257231" y="347.278437" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="478.84589" y="348.27856" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="479.434549" y="349.255133" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="480.023209" y="350.208483" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="480.611868" y="351.138941" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="481.200527" y="352.046842" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="481.789187" y="352.932521" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="482.377846" y="353.79632" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="482.966505" y="354.63858" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="483.555165" y="355.459645" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="484.143824" y="356.259861" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="484.732484" y="357.039576" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="485.321143" y="357.799137" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="485.909802" y="358.538894" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="486.498462" y="359.259197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="487.087121" y="359.960398" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="487.67578" y="360.642848" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="488.26444" y="361.3069" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="488.853099" y="361.952908" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="489.441758" y="362.581226" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="490.030418" y="363.192205" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="490.619077" y="363.786196" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="491.207736" y="364.359297" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="491.796396" y="364.916095" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="492.385055" y="365.456926" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="492.973714" y="365.982122" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="493.562374" y="366.492014" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="494.151033" y="366.98693" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="494.739692" y="367.467195" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="495.328352" y="367.933135" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="495.917011" y="368.385072" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="496.50567" y="368.823327" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="497.09433" y="369.248217" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="497.682989" y="369.660056" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="498.271648" y="370.059154" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="498.860308" y="370.445819" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="499.448967" y="370.820353" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="500.037626" y="371.183056" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="500.626286" y="371.534221" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="501.214945" y="371.874141" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="501.803604" y="372.203101" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="502.392264" y="372.521385" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="502.980923" y="372.829269" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="503.569582" y="373.127028" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="504.158242" y="373.41493" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="504.746901" y="373.69324" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="505.33556" y="373.962219" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="505.92422" y="374.222123" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="506.512879" y="374.473205" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="507.101538" y="374.715715" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="507.690198" y="374.949898" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="508.278857" y="375.176002" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="508.867516" y="375.394199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="509.456176" y="375.604492" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="510.044835" y="375.806942" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="510.633495" y="376.00193" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="511.222154" y="376.189896" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="511.810813" y="376.37111" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="512.399473" y="376.545768" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="512.988132" y="376.714066" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="513.576791" y="376.876198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="514.165451" y="377.032352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="514.75411" y="377.182717" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="515.342769" y="377.327474" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="515.931429" y="377.466803" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="516.520088" y="377.600877" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="517.108747" y="377.729866" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="517.697407" y="377.853938" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="518.286066" y="377.973252" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="518.874725" y="378.087967" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="519.463385" y="378.198236" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="520.052044" y="378.304208" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="520.640703" y="378.406028" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="521.229363" y="378.503838" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="521.818022" y="378.597777" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="522.406681" y="378.687977" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="522.995341" y="378.774569" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="523.584" y="378.85768" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="524.172659" y="378.937434" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="524.761319" y="379.013949" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="525.349978" y="379.087343" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="525.938637" y="379.157726" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="526.527297" y="379.225209" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="527.115956" y="379.289898" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="527.704615" y="379.35188" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="528.293275" y="379.411215" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="528.881934" y="379.467976" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="529.470593" y="379.52228" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="530.059253" y="379.574259" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="530.647912" y="379.624016" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="531.236571" y="379.671635" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="531.825231" y="379.717198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="532.41389" y="379.760785" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="533.002549" y="379.802472" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="533.591209" y="379.842333" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="534.179868" y="379.88044" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="534.768527" y="379.916862" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="535.357187" y="379.951666" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="535.945846" y="379.984917" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="536.534505" y="380.016677" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="537.123165" y="380.047007" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="537.711824" y="380.075965" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="538.300484" y="380.103607" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="538.889143" y="380.129987" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="539.477802" y="380.155158" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="540.066462" y="380.179171" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="540.655121" y="380.202073" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="541.24378" y="380.223913" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="541.83244" y="380.244734" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="542.421099" y="380.26458" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="543.009758" y="380.283493" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="543.598418" y="380.301513" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="544.187077" y="380.318678" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="544.775736" y="380.335026" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="545.364396" y="380.350594" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="545.953055" y="380.365414" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="546.541714" y="380.379519" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="547.130374" y="380.392965" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="547.719033" y="380.405647" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="548.307692" y="380.41773" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="548.896352" y="380.429217" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="549.485011" y="380.440136" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="550.07367" y="380.450515" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="550.66233" y="380.460377" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="551.250989" y="380.469745" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="551.839648" y="380.478644" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="552.428308" y="380.487094" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="553.016967" y="380.495117" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="553.605626" y="380.502732" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="554.194286" y="380.50996" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="554.782945" y="380.516817" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="555.371604" y="380.523323" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="555.960264" y="380.529493" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="556.548923" y="380.535345" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="557.137582" y="380.540892" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="557.726242" y="380.54615" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="558.314901" y="380.551134" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="558.90356" y="380.555855" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="559.49222" y="380.560328" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="560.080879" y="380.564565" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="560.669538" y="380.568577" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="561.258198" y="380.572375" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="561.846857" y="380.575971" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="562.435516" y="380.579374" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="563.024176" y="380.582594" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="563.612835" y="380.585641" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="564.201495" y="380.588523" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="564.790154" y="380.591249" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="565.378813" y="380.593827" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="565.967473" y="380.596259" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="566.556132" y="380.598542" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="567.144791" y="380.600692" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="567.733451" y="380.602724" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="568.32211" y="380.604642" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="568.910769" y="380.606453" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="569.499429" y="380.608162" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="570.088088" y="380.609774" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="570.676747" y="380.611295" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="571.265407" y="380.61273" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="571.854066" y="380.614083" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="572.442725" y="380.615359" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="573.031385" y="380.616561" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="573.620044" y="380.617694" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="574.208703" y="380.618761" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="574.797363" y="380.619767" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="575.386022" y="380.620714" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="575.974681" y="380.621606" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="576.563341" y="380.622446" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="577.152" y="380.623236" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="577.740659" y="380.62398" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="578.329319" y="380.624679" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="578.917978" y="380.625338" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="579.506637" y="380.625957" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="580.095297" y="380.626539" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="580.683956" y="380.627086" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="581.272615" y="380.627601" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="581.861275" y="380.628084" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="582.449934" y="380.628539" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="583.038593" y="380.628965" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="583.627253" y="380.629366" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="584.215912" y="380.629743" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="584.804571" y="380.630096" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="585.393231" y="380.630426" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="585.98189" y="380.630735" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="586.570549" y="380.631024" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="587.159209" y="380.631296" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="587.747868" y="380.631551" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="588.336527" y="380.63179" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="588.925187" y="380.632014" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="589.513846" y="380.632223" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="590.102505" y="380.63242" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="590.691165" y="380.632604" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="591.279824" y="380.632776" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="591.868484" y="380.632938" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="592.457143" y="380.633089" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="593.045802" y="380.63323" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="593.634462" y="380.633362" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="594.223121" y="380.633486" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="594.81178" y="380.633602" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="595.40044" y="380.63371" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="595.989099" y="380.633811" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="596.577758" y="380.633906" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="597.166418" y="380.633995" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="597.755077" y="380.634077" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="598.343736" y="380.634154" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="598.932396" y="380.634226" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="599.521055" y="380.634294" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="600.109714" y="380.634357" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="600.698374" y="380.634415" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="601.287033" y="380.63447" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="601.875692" y="380.634521" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="602.464352" y="380.634569" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="603.053011" y="380.634613" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="603.64167" y="380.634655" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="604.23033" y="380.634693" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="604.818989" y="380.634729" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="605.407648" y="380.634762" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="605.996308" y="380.634794" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="606.584967" y="380.634823" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="607.173626" y="380.634849" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="607.762286" y="380.634875" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="608.350945" y="380.634898" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="608.939604" y="380.63492" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="609.528264" y="380.63494" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="610.116923" y="380.634959" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="610.705582" y="380.634976" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="611.294242" y="380.634993" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="611.882901" y="380.635008" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="612.47156" y="380.635022" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="613.06022" y="380.635035" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="613.648879" y="380.635047" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="614.237538" y="380.635058" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="614.826198" y="380.635069" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="615.414857" y="380.635078" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="616.003516" y="380.635088" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="616.592176" y="380.635096" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="617.180835" y="380.635104" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="617.769495" y="380.635111" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="618.358154" y="380.635118" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="618.946813" y="380.635124" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="619.535473" y="380.63513" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="620.124132" y="380.635135" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="620.712791" y="380.63514" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="621.301451" y="380.635144" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="621.89011" y="380.635149" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="622.478769" y="380.635153" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="623.067429" y="380.635156" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="623.656088" y="380.63516" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="624.244747" y="380.635163" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="624.833407" y="380.635166" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="625.422066" y="380.635168" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="626.010725" y="380.635171" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="626.599385" y="380.635173" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="627.188044" y="380.635175" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="627.776703" y="380.635177" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="628.365363" y="380.635179" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="628.954022" y="380.63518" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="629.542681" y="380.635182" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="630.131341" y="380.635183" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="630.72" y="380.635185" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="631.308659" y="380.635186" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="631.897319" y="380.635187" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="632.485978" y="380.635188" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="633.074637" y="380.635189" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="633.663297" y="380.63519" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="634.251956" y="380.635191" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="634.840615" y="380.635191" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="635.429275" y="380.635192" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="636.017934" y="380.635193" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="636.606593" y="380.635193" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="637.195253" y="380.635194" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="637.783912" y="380.635194" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="638.372571" y="380.635195" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="638.961231" y="380.635195" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="639.54989" y="380.635196" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="640.138549" y="380.635196" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="640.727209" y="380.635196" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="641.315868" y="380.635197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="641.904527" y="380.635197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="642.493187" y="380.635197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="643.081846" y="380.635197" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="643.670505" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="644.259165" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="644.847824" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="645.436484" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="646.025143" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="646.613802" y="380.635198" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="647.202462" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="647.791121" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="648.37978" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="648.96844" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="649.557099" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="650.145758" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="650.734418" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="651.323077" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="651.911736" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="652.500396" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="653.089055" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="653.677714" y="380.635199" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="654.266374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="654.855033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="655.443692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="656.032352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="656.621011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="657.20967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="657.79833" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="658.386989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="658.975648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="659.564308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="660.152967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="660.741626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="661.330286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="661.918945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="662.507604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="663.096264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="663.684923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="664.273582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="664.862242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="665.450901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="666.03956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="666.62822" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="667.216879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="667.805538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="668.394198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="668.982857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="669.571516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="670.160176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="670.748835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="671.337495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="671.926154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="672.514813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="673.103473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="673.692132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="674.280791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="674.869451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="675.45811" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="676.046769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="676.635429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="677.224088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="677.812747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="678.401407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="678.990066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="679.578725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="680.167385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="680.756044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="681.344703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="681.933363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="682.522022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="683.110681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7b5e1d1292" x="683.699341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 95.04 380.6352 
+L 95.04 51.3216 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 684.288 380.6352 
+L 684.288 51.3216 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 95.04 380.6352 
+L 684.288 380.6352 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 95.04 51.3216 
+L 684.288 51.3216 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- T = 10000 -->
+    <g transform="translate(326.4765 45.3216)scale(0.24 -0.24)">
+     <defs>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-20" x="61.083984"/>
+     <use xlink:href="#DejaVuSans-3d" x="92.871094"/>
+     <use xlink:href="#DejaVuSans-20" x="176.660156"/>
+     <use xlink:href="#DejaVuSans-31" x="208.447266"/>
+     <use xlink:href="#DejaVuSans-30" x="272.070312"/>
+     <use xlink:href="#DejaVuSans-30" x="335.693359"/>
+     <use xlink:href="#DejaVuSans-30" x="399.316406"/>
+     <use xlink:href="#DejaVuSans-30" x="462.939453"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p24d58054f1">
+   <rect x="95.04" y="51.3216" width="589.248" height="329.3136"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/source/user/laplace_initial.svg
+++ b/docs/source/user/laplace_initial.svg
@@ -1,0 +1,1838 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="760.32pt" height="427.68pt" viewBox="0 0 760.32 427.68" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2022-04-18T06:58:18.768147</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.5.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 427.68 
+L 760.32 427.68 
+L 760.32 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 95.04 380.6352 
+L 684.288 380.6352 
+L 684.288 51.3216 
+L 95.04 51.3216 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mdbd2280614" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdbd2280614" x="95.04" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(91.85875 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mdbd2280614" x="212.771868" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 200 -->
+      <g transform="translate(203.228118 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mdbd2280614" x="330.503736" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 400 -->
+      <g transform="translate(320.959986 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mdbd2280614" x="448.235604" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 600 -->
+      <g transform="translate(438.691854 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mdbd2280614" x="565.967473" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 800 -->
+      <g transform="translate(556.423723 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mdbd2280614" x="683.699341" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1000 -->
+      <g transform="translate(670.974341 395.233637)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- Position -->
+     <g transform="translate(342.95025 419.549575)scale(0.24 -0.24)">
+      <defs>
+       <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-50"/>
+      <use xlink:href="#DejaVuSans-6f" x="56.677734"/>
+      <use xlink:href="#DejaVuSans-73" x="117.859375"/>
+      <use xlink:href="#DejaVuSans-69" x="169.958984"/>
+      <use xlink:href="#DejaVuSans-74" x="197.742188"/>
+      <use xlink:href="#DejaVuSans-69" x="236.951172"/>
+      <use xlink:href="#DejaVuSans-6f" x="264.734375"/>
+      <use xlink:href="#DejaVuSans-6e" x="325.916016"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <defs>
+       <path id="maf970daf46" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#maf970daf46" x="95.04" y="380.6352" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(81.6775 384.434419)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#maf970daf46" x="95.04" y="314.779066" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2000 -->
+      <g transform="translate(62.59 318.578284)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#maf970daf46" x="95.04" y="248.922931" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 4000 -->
+      <g transform="translate(62.59 252.72215)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#maf970daf46" x="95.04" y="183.066797" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6000 -->
+      <g transform="translate(62.59 186.866016)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#maf970daf46" x="95.04" y="117.210662" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 8000 -->
+      <g transform="translate(62.59 121.009881)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-38"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#maf970daf46" x="95.04" y="51.354528" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 10000 -->
+      <g transform="translate(56.2275 55.153747)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-30" x="254.492188"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- Temperature -->
+     <g transform="translate(47.23625 291.985275)rotate(-90)scale(0.24 -0.24)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-65" x="44.083984"/>
+      <use xlink:href="#DejaVuSans-6d" x="105.607422"/>
+      <use xlink:href="#DejaVuSans-70" x="203.019531"/>
+      <use xlink:href="#DejaVuSans-65" x="266.496094"/>
+      <use xlink:href="#DejaVuSans-72" x="328.019531"/>
+      <use xlink:href="#DejaVuSans-61" x="369.132812"/>
+      <use xlink:href="#DejaVuSans-74" x="430.412109"/>
+      <use xlink:href="#DejaVuSans-75" x="469.621094"/>
+      <use xlink:href="#DejaVuSans-72" x="533"/>
+      <use xlink:href="#DejaVuSans-65" x="571.863281"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_13">
+    <path d="M 95.04 380.6352 
+L 388.781011 380.6352 
+L 389.36967 51.354528 
+L 389.95833 380.6352 
+L 683.699341 380.6352 
+L 683.699341 380.6352 
+" clip-path="url(#pe338a5f14f)" style="fill: none; stroke: #000000; stroke-width: 3; stroke-linecap: square"/>
+    <defs>
+     <path id="m9f78a702ea" d="M 0 -3 
+L -0.673542 -0.927051 
+L -2.85317 -0.927051 
+L -1.089814 0.354102 
+L -1.763356 2.427051 
+L -0 1.145898 
+L 1.763356 2.427051 
+L 1.089814 0.354102 
+L 2.85317 -0.927051 
+L 0.673542 -0.927051 
+z
+" style="stroke: #000000; stroke-linejoin: bevel"/>
+    </defs>
+    <g clip-path="url(#pe338a5f14f)">
+     <use xlink:href="#m9f78a702ea" x="95.04" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="95.628659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="96.217319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="96.805978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="97.394637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="97.983297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="98.571956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="99.160615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="99.749275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="100.337934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="100.926593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="101.515253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="102.103912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="102.692571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="103.281231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="103.86989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="104.458549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="105.047209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="105.635868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="106.224527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="106.813187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="107.401846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="107.990505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="108.579165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="109.167824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="109.756484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="110.345143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="110.933802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="111.522462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="112.111121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="112.69978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="113.28844" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="113.877099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="114.465758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="115.054418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="115.643077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="116.231736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="116.820396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="117.409055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="117.997714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="118.586374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="119.175033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="119.763692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="120.352352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="120.941011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="121.52967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="122.11833" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="122.706989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="123.295648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="123.884308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="124.472967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="125.061626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="125.650286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="126.238945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="126.827604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="127.416264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="128.004923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="128.593582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="129.182242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="129.770901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="130.35956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="130.94822" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="131.536879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="132.125538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="132.714198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="133.302857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="133.891516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="134.480176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="135.068835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="135.657495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="136.246154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="136.834813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="137.423473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="138.012132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="138.600791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="139.189451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="139.77811" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="140.366769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="140.955429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="141.544088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="142.132747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="142.721407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="143.310066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="143.898725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="144.487385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="145.076044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="145.664703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="146.253363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="146.842022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="147.430681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="148.019341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="148.608" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="149.196659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="149.785319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="150.373978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="150.962637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="151.551297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="152.139956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="152.728615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="153.317275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="153.905934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="154.494593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="155.083253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="155.671912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="156.260571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="156.849231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="157.43789" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="158.026549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="158.615209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="159.203868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="159.792527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="160.381187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="160.969846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="161.558505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="162.147165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="162.735824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="163.324484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="163.913143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="164.501802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="165.090462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="165.679121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="166.26778" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="166.85644" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="167.445099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="168.033758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="168.622418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="169.211077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="169.799736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="170.388396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="170.977055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="171.565714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="172.154374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="172.743033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="173.331692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="173.920352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="174.509011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="175.09767" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="175.68633" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="176.274989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="176.863648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="177.452308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="178.040967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="178.629626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="179.218286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="179.806945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="180.395604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="180.984264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="181.572923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="182.161582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="182.750242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="183.338901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="183.92756" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="184.51622" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="185.104879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="185.693538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="186.282198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="186.870857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="187.459516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="188.048176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="188.636835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="189.225495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="189.814154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="190.402813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="190.991473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="191.580132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="192.168791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="192.757451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="193.34611" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="193.934769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="194.523429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="195.112088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="195.700747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="196.289407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="196.878066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="197.466725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="198.055385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="198.644044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="199.232703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="199.821363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="200.410022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="200.998681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="201.587341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="202.176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="202.764659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="203.353319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="203.941978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="204.530637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="205.119297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="205.707956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="206.296615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="206.885275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="207.473934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="208.062593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="208.651253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="209.239912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="209.828571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="210.417231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="211.00589" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="211.594549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="212.183209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="212.771868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="213.360527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="213.949187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="214.537846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="215.126505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="215.715165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="216.303824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="216.892484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="217.481143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="218.069802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="218.658462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="219.247121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="219.83578" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="220.42444" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="221.013099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="221.601758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="222.190418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="222.779077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="223.367736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="223.956396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="224.545055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="225.133714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="225.722374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="226.311033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="226.899692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="227.488352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="228.077011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="228.66567" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="229.25433" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="229.842989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="230.431648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="231.020308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="231.608967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="232.197626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="232.786286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="233.374945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="233.963604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="234.552264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="235.140923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="235.729582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="236.318242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="236.906901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="237.49556" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="238.08422" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="238.672879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="239.261538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="239.850198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="240.438857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="241.027516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="241.616176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="242.204835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="242.793495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="243.382154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="243.970813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="244.559473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="245.148132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="245.736791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="246.325451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="246.91411" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="247.502769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="248.091429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="248.680088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="249.268747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="249.857407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="250.446066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="251.034725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="251.623385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="252.212044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="252.800703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="253.389363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="253.978022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="254.566681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="255.155341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="255.744" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="256.332659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="256.921319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="257.509978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="258.098637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="258.687297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="259.275956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="259.864615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="260.453275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="261.041934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="261.630593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="262.219253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="262.807912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="263.396571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="263.985231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="264.57389" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="265.162549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="265.751209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="266.339868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="266.928527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="267.517187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="268.105846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="268.694505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="269.283165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="269.871824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="270.460484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="271.049143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="271.637802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="272.226462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="272.815121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="273.40378" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="273.99244" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="274.581099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="275.169758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="275.758418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="276.347077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="276.935736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="277.524396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="278.113055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="278.701714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="279.290374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="279.879033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="280.467692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="281.056352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="281.645011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="282.23367" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="282.82233" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="283.410989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="283.999648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="284.588308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="285.176967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="285.765626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="286.354286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="286.942945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="287.531604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="288.120264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="288.708923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="289.297582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="289.886242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="290.474901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="291.06356" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="291.65222" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="292.240879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="292.829538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="293.418198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="294.006857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="294.595516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="295.184176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="295.772835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="296.361495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="296.950154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="297.538813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="298.127473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="298.716132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="299.304791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="299.893451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="300.48211" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="301.070769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="301.659429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="302.248088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="302.836747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="303.425407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="304.014066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="304.602725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="305.191385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="305.780044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="306.368703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="306.957363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="307.546022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="308.134681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="308.723341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="309.312" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="309.900659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="310.489319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="311.077978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="311.666637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="312.255297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="312.843956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="313.432615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="314.021275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="314.609934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="315.198593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="315.787253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="316.375912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="316.964571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="317.553231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="318.14189" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="318.730549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="319.319209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="319.907868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="320.496527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="321.085187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="321.673846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="322.262505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="322.851165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="323.439824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="324.028484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="324.617143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="325.205802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="325.794462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="326.383121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="326.97178" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="327.56044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="328.149099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="328.737758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="329.326418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="329.915077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="330.503736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="331.092396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="331.681055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="332.269714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="332.858374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="333.447033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="334.035692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="334.624352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="335.213011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="335.80167" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="336.39033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="336.978989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="337.567648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="338.156308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="338.744967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="339.333626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="339.922286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="340.510945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="341.099604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="341.688264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="342.276923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="342.865582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="343.454242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="344.042901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="344.63156" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="345.22022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="345.808879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="346.397538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="346.986198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="347.574857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="348.163516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="348.752176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="349.340835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="349.929495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="350.518154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="351.106813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="351.695473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="352.284132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="352.872791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="353.461451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="354.05011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="354.638769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="355.227429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="355.816088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="356.404747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="356.993407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="357.582066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="358.170725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="358.759385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="359.348044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="359.936703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="360.525363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="361.114022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="361.702681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="362.291341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="362.88" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="363.468659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="364.057319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="364.645978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="365.234637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="365.823297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="366.411956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="367.000615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="367.589275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="368.177934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="368.766593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="369.355253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="369.943912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="370.532571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="371.121231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="371.70989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="372.298549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="372.887209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="373.475868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="374.064527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="374.653187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="375.241846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="375.830505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="376.419165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="377.007824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="377.596484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="378.185143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="378.773802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="379.362462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="379.951121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="380.53978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="381.12844" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="381.717099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="382.305758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="382.894418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="383.483077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="384.071736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="384.660396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="385.249055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="385.837714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="386.426374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="387.015033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="387.603692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="388.192352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="388.781011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="389.36967" y="51.354528" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="389.95833" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="390.546989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="391.135648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="391.724308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="392.312967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="392.901626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="393.490286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="394.078945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="394.667604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="395.256264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="395.844923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="396.433582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="397.022242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="397.610901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="398.19956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="398.78822" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="399.376879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="399.965538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="400.554198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="401.142857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="401.731516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="402.320176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="402.908835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="403.497495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="404.086154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="404.674813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="405.263473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="405.852132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="406.440791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="407.029451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="407.61811" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="408.206769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="408.795429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="409.384088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="409.972747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="410.561407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="411.150066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="411.738725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="412.327385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="412.916044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="413.504703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="414.093363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="414.682022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="415.270681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="415.859341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="416.448" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="417.036659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="417.625319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="418.213978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="418.802637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="419.391297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="419.979956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="420.568615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="421.157275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="421.745934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="422.334593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="422.923253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="423.511912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="424.100571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="424.689231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="425.27789" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="425.866549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="426.455209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="427.043868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="427.632527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="428.221187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="428.809846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="429.398505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="429.987165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="430.575824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="431.164484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="431.753143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="432.341802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="432.930462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="433.519121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="434.10778" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="434.69644" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="435.285099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="435.873758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="436.462418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="437.051077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="437.639736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="438.228396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="438.817055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="439.405714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="439.994374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="440.583033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="441.171692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="441.760352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="442.349011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="442.93767" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="443.52633" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="444.114989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="444.703648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="445.292308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="445.880967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="446.469626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="447.058286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="447.646945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="448.235604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="448.824264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="449.412923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="450.001582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="450.590242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="451.178901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="451.76756" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="452.35622" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="452.944879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="453.533538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="454.122198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="454.710857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="455.299516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="455.888176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="456.476835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="457.065495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="457.654154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="458.242813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="458.831473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="459.420132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="460.008791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="460.597451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="461.18611" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="461.774769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="462.363429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="462.952088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="463.540747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="464.129407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="464.718066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="465.306725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="465.895385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="466.484044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="467.072703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="467.661363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="468.250022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="468.838681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="469.427341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="470.016" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="470.604659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="471.193319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="471.781978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="472.370637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="472.959297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="473.547956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="474.136615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="474.725275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="475.313934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="475.902593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="476.491253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="477.079912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="477.668571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="478.257231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="478.84589" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="479.434549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="480.023209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="480.611868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="481.200527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="481.789187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="482.377846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="482.966505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="483.555165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="484.143824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="484.732484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="485.321143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="485.909802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="486.498462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="487.087121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="487.67578" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="488.26444" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="488.853099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="489.441758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="490.030418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="490.619077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="491.207736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="491.796396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="492.385055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="492.973714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="493.562374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="494.151033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="494.739692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="495.328352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="495.917011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="496.50567" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="497.09433" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="497.682989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="498.271648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="498.860308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="499.448967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="500.037626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="500.626286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="501.214945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="501.803604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="502.392264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="502.980923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="503.569582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="504.158242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="504.746901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="505.33556" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="505.92422" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="506.512879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="507.101538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="507.690198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="508.278857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="508.867516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="509.456176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="510.044835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="510.633495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="511.222154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="511.810813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="512.399473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="512.988132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="513.576791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="514.165451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="514.75411" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="515.342769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="515.931429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="516.520088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="517.108747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="517.697407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="518.286066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="518.874725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="519.463385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="520.052044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="520.640703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="521.229363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="521.818022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="522.406681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="522.995341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="523.584" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="524.172659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="524.761319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="525.349978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="525.938637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="526.527297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="527.115956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="527.704615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="528.293275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="528.881934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="529.470593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="530.059253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="530.647912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="531.236571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="531.825231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="532.41389" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="533.002549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="533.591209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="534.179868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="534.768527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="535.357187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="535.945846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="536.534505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="537.123165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="537.711824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="538.300484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="538.889143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="539.477802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="540.066462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="540.655121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="541.24378" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="541.83244" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="542.421099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="543.009758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="543.598418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="544.187077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="544.775736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="545.364396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="545.953055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="546.541714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="547.130374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="547.719033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="548.307692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="548.896352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="549.485011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="550.07367" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="550.66233" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="551.250989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="551.839648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="552.428308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="553.016967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="553.605626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="554.194286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="554.782945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="555.371604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="555.960264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="556.548923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="557.137582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="557.726242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="558.314901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="558.90356" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="559.49222" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="560.080879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="560.669538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="561.258198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="561.846857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="562.435516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="563.024176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="563.612835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="564.201495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="564.790154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="565.378813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="565.967473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="566.556132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="567.144791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="567.733451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="568.32211" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="568.910769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="569.499429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="570.088088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="570.676747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="571.265407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="571.854066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="572.442725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="573.031385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="573.620044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="574.208703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="574.797363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="575.386022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="575.974681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="576.563341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="577.152" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="577.740659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="578.329319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="578.917978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="579.506637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="580.095297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="580.683956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="581.272615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="581.861275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="582.449934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="583.038593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="583.627253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="584.215912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="584.804571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="585.393231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="585.98189" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="586.570549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="587.159209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="587.747868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="588.336527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="588.925187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="589.513846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="590.102505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="590.691165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="591.279824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="591.868484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="592.457143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="593.045802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="593.634462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="594.223121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="594.81178" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="595.40044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="595.989099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="596.577758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="597.166418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="597.755077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="598.343736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="598.932396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="599.521055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="600.109714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="600.698374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="601.287033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="601.875692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="602.464352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="603.053011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="603.64167" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="604.23033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="604.818989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="605.407648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="605.996308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="606.584967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="607.173626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="607.762286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="608.350945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="608.939604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="609.528264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="610.116923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="610.705582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="611.294242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="611.882901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="612.47156" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="613.06022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="613.648879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="614.237538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="614.826198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="615.414857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="616.003516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="616.592176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="617.180835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="617.769495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="618.358154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="618.946813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="619.535473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="620.124132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="620.712791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="621.301451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="621.89011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="622.478769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="623.067429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="623.656088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="624.244747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="624.833407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="625.422066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="626.010725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="626.599385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="627.188044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="627.776703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="628.365363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="628.954022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="629.542681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="630.131341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="630.72" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="631.308659" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="631.897319" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="632.485978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="633.074637" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="633.663297" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="634.251956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="634.840615" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="635.429275" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="636.017934" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="636.606593" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="637.195253" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="637.783912" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="638.372571" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="638.961231" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="639.54989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="640.138549" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="640.727209" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="641.315868" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="641.904527" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="642.493187" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="643.081846" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="643.670505" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="644.259165" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="644.847824" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="645.436484" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="646.025143" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="646.613802" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="647.202462" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="647.791121" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="648.37978" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="648.96844" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="649.557099" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="650.145758" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="650.734418" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="651.323077" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="651.911736" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="652.500396" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="653.089055" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="653.677714" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="654.266374" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="654.855033" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="655.443692" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="656.032352" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="656.621011" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="657.20967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="657.79833" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="658.386989" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="658.975648" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="659.564308" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="660.152967" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="660.741626" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="661.330286" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="661.918945" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="662.507604" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="663.096264" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="663.684923" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="664.273582" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="664.862242" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="665.450901" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="666.03956" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="666.62822" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="667.216879" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="667.805538" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="668.394198" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="668.982857" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="669.571516" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="670.160176" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="670.748835" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="671.337495" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="671.926154" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="672.514813" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="673.103473" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="673.692132" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="674.280791" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="674.869451" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="675.45811" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="676.046769" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="676.635429" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="677.224088" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="677.812747" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="678.401407" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="678.990066" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="679.578725" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="680.167385" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="680.756044" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="681.344703" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="681.933363" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="682.522022" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="683.110681" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9f78a702ea" x="683.699341" y="380.6352" style="stroke: #000000; stroke-linejoin: bevel"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 95.04 380.6352 
+L 95.04 51.3216 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 684.288 380.6352 
+L 684.288 51.3216 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 95.04 380.6352 
+L 684.288 380.6352 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 95.04 51.3216 
+L 684.288 51.3216 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- Initial State -->
+    <g transform="translate(320.8815 45.3216)scale(0.24 -0.24)">
+     <defs>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-49"/>
+     <use xlink:href="#DejaVuSans-6e" x="29.492188"/>
+     <use xlink:href="#DejaVuSans-69" x="92.871094"/>
+     <use xlink:href="#DejaVuSans-74" x="120.654297"/>
+     <use xlink:href="#DejaVuSans-69" x="159.863281"/>
+     <use xlink:href="#DejaVuSans-61" x="187.646484"/>
+     <use xlink:href="#DejaVuSans-6c" x="248.925781"/>
+     <use xlink:href="#DejaVuSans-20" x="276.708984"/>
+     <use xlink:href="#DejaVuSans-53" x="308.496094"/>
+     <use xlink:href="#DejaVuSans-74" x="371.972656"/>
+     <use xlink:href="#DejaVuSans-61" x="411.181641"/>
+     <use xlink:href="#DejaVuSans-74" x="472.460938"/>
+     <use xlink:href="#DejaVuSans-65" x="511.669922"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pe338a5f14f">
+   <rect x="95.04" y="51.3216" width="589.248" height="329.3136"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/source/user/memory.rst
+++ b/docs/source/user/memory.rst
@@ -1,0 +1,345 @@
+=================
+Memory management
+=================
+
+.. _cuda-device-memory:
+
+Data transfer
+=============
+
+Even though Numba can automatically transfer NumPy arrays to the device,
+it can only do so conservatively by always transferring device memory back to
+the host when a kernel finishes. To avoid the unnecessary transfer for
+read-only arrays, you can use the following APIs to manually control the
+transfer:
+
+.. autofunction:: numba.cuda.device_array
+   :noindex:
+.. autofunction:: numba.cuda.device_array_like
+   :noindex:
+.. autofunction:: numba.cuda.to_device
+   :noindex:
+
+In addition to the device arrays, Numba can consume any object that implements
+:ref:`cuda array interface <cuda-array-interface>`.  These objects also can be
+manually converted into a Numba device array by creating a view of the GPU
+buffer using the following APIs:
+
+.. autofunction:: numba.cuda.as_cuda_array
+  :noindex:
+.. autofunction:: numba.cuda.is_cuda_array
+  :noindex:
+
+
+Device arrays
+-------------
+
+Device array references have the following methods.  These methods are to be
+called in host code, not within CUDA-jitted functions.
+
+.. autoclass:: numba.cuda.cudadrv.devicearray.DeviceNDArray
+    :members: copy_to_host, is_c_contiguous, is_f_contiguous, ravel, reshape
+    :noindex:
+
+
+.. note:: DeviceNDArray defines the :ref:`cuda array interface <cuda-array-interface>`.
+
+
+Pinned memory
+=============
+
+.. autofunction:: numba.cuda.pinned
+   :noindex:
+.. autofunction:: numba.cuda.pinned_array
+   :noindex:
+.. autofunction:: numba.cuda.pinned_array_like
+   :noindex:
+
+
+Mapped memory
+=============
+
+.. autofunction:: numba.cuda.mapped
+   :noindex:
+.. autofunction:: numba.cuda.mapped_array
+   :noindex:
+.. autofunction:: numba.cuda.mapped_array_like
+   :noindex:
+
+
+
+Managed memory
+==============
+
+.. autofunction:: numba.cuda.managed_array
+   :noindex:
+
+
+Streams
+=======
+
+Streams can be passed to functions that accept them (e.g. copies between the
+host and device) and into kernel launch configurations so that the operations
+are executed asynchronously.
+
+.. autofunction:: numba.cuda.stream
+   :noindex:
+
+.. autofunction:: numba.cuda.default_stream
+   :noindex:
+
+.. autofunction:: numba.cuda.legacy_default_stream
+   :noindex:
+
+.. autofunction:: numba.cuda.per_thread_default_stream
+   :noindex:
+
+.. autofunction:: numba.cuda.external_stream
+   :noindex:
+
+CUDA streams have the following methods:
+
+.. autoclass:: numba.cuda.cudadrv.driver.Stream
+    :members: synchronize, auto_synchronize
+    :noindex:
+
+.. _cuda-shared-memory:
+
+Shared memory and thread synchronization
+========================================
+
+A limited amount of shared memory can be allocated on the device to speed
+up access to data, when necessary.  That memory will be shared (i.e. both
+readable and writable) amongst all threads belonging to a given block
+and has faster access times than regular device memory.  It also allows
+threads to cooperate on a given solution.  You can think of it as a
+manually-managed data cache.
+
+The memory is allocated once for the duration of the kernel, unlike
+traditional dynamic memory management.
+
+.. function:: numba.cuda.shared.array(shape, type)
+   :noindex:
+
+   Allocate a shared array of the given *shape* and *type* on the device.
+   This function must be called on the device (i.e. from a kernel or
+   device function). *shape* is either an integer or a tuple of integers
+   representing the array's dimensions and must be a simple constant
+   expression. A "simple constant expression" includes, but is not limited to:
+   
+      #. A literal (e.g. ``10``)
+      #. A local variable whose right-hand side is a literal or a simple constant
+         expression (e.g. ``shape``, where ``shape`` is defined earlier in the function 
+         as ``shape = 10``)
+      #. A global variable that is defined in the jitted function's globals by the time
+         of compilation (e.g. ``shape``, where ``shape`` is defined using any expression
+         at global scope).
+
+   The definition must result in a Python ``int`` (i.e. not a NumPy scalar or other
+   scalar / integer-like type). *type* is a :ref:`Numba type <numba-types>` of the
+   elements needing to be stored in the array. The returned array-like object can be
+   read and written to like any normal device array (e.g. through indexing).
+
+   A common pattern is to have each thread populate one element in the
+   shared array and then wait for all threads to finish using :func:`.syncthreads`.
+
+
+.. function:: numba.cuda.syncthreads()
+   :noindex:
+
+   Synchronize all threads in the same thread block.  This function
+   implements the same pattern as `barriers <http://en.wikipedia.org/wiki/Barrier_%28computer_science%29>`_
+   in traditional multi-threaded programming: this function waits
+   until all threads in the block call it, at which point it returns
+   control to all its callers.
+
+.. seealso::
+   :ref:`Matrix multiplication example <cuda-matmul>`.
+
+Dynamic Shared Memory
+---------------------
+
+In order to use dynamic shared memory in kernel code declare a shared array of
+size 0:
+
+.. code-block:: python
+
+   @cuda.jit
+   def kernel_func(x):
+      dyn_arr = cuda.shared.array(0, dtype=np.float32)
+      ...
+
+and specify the size of dynamic shared memory in bytes during kernel invocation:
+
+.. code-block:: python
+
+   kernel_func[32, 32, 0, 128](x)
+
+In the above code the kernel launch is configured with 4 parameters:
+
+.. code-block:: python
+
+   kernel_func[grid_dim, block_dim, stream, dyn_shared_mem_size]
+
+**Note:** all dynamic shared memory arrays *alias*, so if you want to have
+multiple dynamic shared arrays, you need to take *disjoint* views of the arrays.
+For example, consider:
+
+.. code-block:: python
+
+   from numba import cuda
+   import numpy as np
+
+   @cuda.jit
+   def f():
+      f32_arr = cuda.shared.array(0, dtype=np.float32)
+      i32_arr = cuda.shared.array(0, dtype=np.int32)
+      f32_arr[0] = 3.14
+      print(f32_arr[0])
+      print(i32_arr[0])
+
+   f[1, 1, 0, 4]()
+   cuda.synchronize()
+
+This allocates 4 bytes of shared memory (large enough for one ``int32`` or one
+``float32``) and declares dynamic shared memory arrays of type ``int32`` and of
+type ``float32``. When ``f32_arr[0]`` is set, this also sets the value of
+``i32_arr[0]``, because they're pointing at the same memory. So we see as
+output:
+
+.. code-block:: pycon
+
+   3.140000
+   1078523331
+
+because 1078523331 is the ``int32`` represented by the bits of the ``float32``
+value 3.14.
+
+If we take disjoint views of the dynamic shared memory:
+
+.. code-block:: python
+
+   from numba import cuda
+   import numpy as np
+
+   @cuda.jit
+   def f_with_view():
+      f32_arr = cuda.shared.array(0, dtype=np.float32)
+      i32_arr = cuda.shared.array(0, dtype=np.int32)[1:] # 1 int32 = 4 bytes
+      f32_arr[0] = 3.14
+      i32_arr[0] = 1
+      print(f32_arr[0])
+      print(i32_arr[0])
+
+   f_with_view[1, 1, 0, 8]()
+   cuda.synchronize()
+
+This time we declare 8 dynamic shared memory bytes, using the first 4 for a
+``float32`` value and the next 4 for an ``int32`` value. Now we can set both the
+``int32`` and ``float32`` value without them aliasing:
+
+.. code-block:: pycon
+
+   3.140000
+   1
+
+
+.. _cuda-local-memory:
+
+Local memory
+============
+
+Local memory is an area of memory private to each thread.  Using local
+memory helps allocate some scratchpad area when scalar local variables
+are not enough.  The memory is allocated once for the duration of the kernel,
+unlike traditional dynamic memory management.
+
+.. function:: numba.cuda.local.array(shape, type)
+   :noindex:
+
+   Allocate a local array of the given *shape* and *type* on the device.
+   *shape* is either an integer or a tuple of integers representing the array's
+   dimensions and must be a simple constant expression. A "simple constant expression" 
+   includes, but is not limited to:
+
+      #. A literal (e.g. ``10``)
+      #. A local variable whose right-hand side is a literal or a simple constant
+         expression (e.g. ``shape``, where ``shape`` is defined earlier in the function
+         as ``shape = 10``)
+      #. A global variable that is defined in the jitted function's globals by the time 
+         of compilation (e.g. ``shape``, where ``shape`` is defined using any expression
+         at global scope).
+
+   The definition must result in a Python ``int`` (i.e. not a NumPy scalar or other
+   scalar / integer-like type). *type* is a :ref:`Numba type <numba-types>`
+   of the elements needing to be stored in the array. The array is private to
+   the current thread. An array-like object is returned which can be read and
+   written to like any standard array (e.g. through indexing).
+
+   .. seealso:: The Local Memory section of `Device Memory Accesses
+      <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#device-memory-accesses>`_
+      in the CUDA programming guide.
+
+Constant memory
+===============
+
+Constant memory is an area of memory that is read only, cached and off-chip, it
+is accessible by all threads and is host allocated. A method of
+creating an array in constant memory is through the use of:
+
+.. function:: numba.cuda.const.array_like(arr)
+   :noindex:
+
+   Allocate and make accessible an array in constant memory based on array-like
+   *arr*.
+
+
+.. _deallocation-behavior:
+
+Deallocation Behavior
+=====================
+
+This section describes the deallocation behaviour of Numba's internal memory
+management. If an External Memory Management Plugin is in use (see
+:ref:`cuda-emm-plugin`), then deallocation behaviour may differ; you may refer to the
+documentation for the EMM Plugin to understand its deallocation behaviour.
+
+Deallocation of all CUDA resources are tracked on a per-context basis.
+When the last reference to a device memory is dropped, the underlying memory
+is scheduled to be deallocated.  The deallocation does not occur immediately.
+It is added to a queue of pending deallocations.  This design has two benefits:
+
+1. Resource deallocation API may cause the device to synchronize; thus, breaking
+   any asynchronous execution.  Deferring the deallocation could avoid latency
+   in performance critical code section.
+2. Some deallocation errors may cause all the remaining deallocations to fail.
+   Continued deallocation errors can cause critical errors at the CUDA driver
+   level.  In some cases, this could mean a segmentation fault in the CUDA
+   driver. In the worst case, this could cause the system GUI to freeze and
+   could only recover with a system reset.  When an error occurs during a
+   deallocation, the remaining pending deallocations are cancelled.  Any
+   deallocation error will be reported.  When the process is terminated, the
+   CUDA driver is able to release all allocated resources by the terminated
+   process.
+
+The deallocation queue is flushed automatically as soon as the following events
+occur:
+
+- An allocation failed due to out-of-memory error.  Allocation is retried after
+  flushing all deallocations.
+- The deallocation queue has reached its maximum size, which is default to 10.
+  User can override by setting the environment variable
+  `NUMBA_CUDA_MAX_PENDING_DEALLOCS_COUNT`.  For example,
+  `NUMBA_CUDA_MAX_PENDING_DEALLOCS_COUNT=20`, increases the limit to 20.
+- The maximum accumulated byte size of resources that are pending deallocation
+  is reached.  This is default to 20% of the device memory capacity.
+  User can override by setting the environment variable
+  `NUMBA_CUDA_MAX_PENDING_DEALLOCS_RATIO`. For example,
+  `NUMBA_CUDA_MAX_PENDING_DEALLOCS_RATIO=0.5` sets the limit to 50% of the
+  capacity.
+
+Sometimes, it is desired to defer resource deallocation until a code section
+ends.  Most often, users want to avoid any implicit synchronization due to
+deallocation.  This can be done by using the following context manager:
+
+.. autofunction:: numba.cuda.defer_cleanup

--- a/docs/source/user/minor_version_compatibility.rst
+++ b/docs/source/user/minor_version_compatibility.rst
@@ -1,0 +1,90 @@
+.. _minor-version-compatibility:
+
+CUDA Minor Version Compatibility
+================================
+
+CUDA `Minor Version Compatibility
+<https://docs.nvidia.com/deploy/cuda-compatibility/index.html#minor-version-compatibility>`_
+(MVC) enables the use of a newer CUDA Toolkit version than the CUDA version
+supported by the driver, provided that the Toolkit and driver both have the same
+major version. For example, use of CUDA Toolkit 11.5 with CUDA driver 450 (CUDA
+version 11.0) is supported through MVC.
+
+Numba supports MVC for CUDA 12 on Linux using the external ``pynvjitlink``
+package.
+
+Numba supports MVC for CUDA 11 on Linux using the external ``cubinlinker`` and
+``ptxcompiler`` packages, subject to the following limitations:
+
+- Linking of archives is unsupported.
+- Cooperative Groups are unsupported, because they require an archive to be
+  linked.
+
+MVC is not supported on Windows.
+
+
+Installation
+------------
+
+CUDA 12
+~~~~~~~
+
+To use MVC support, the ``pynvjitlink`` package must be installed. To install
+using conda, use:
+
+.. code:: bash
+
+   conda install -c rapidsai pynvjitlink
+
+To install with pip, use the NVIDIA package index:
+
+.. code:: bash
+
+   pip install --extra-index-url https://pypi.nvidia.com pynvjitlink-cu12
+
+CUDA 11
+~~~~~~~
+
+To use MVC support, the ``cubinlinker`` and ``ptxcompiler`` compiler packages
+must be installed from the appropriate channels. To install using conda, use:
+
+.. code:: bash
+
+   conda install -c rapidsai -c conda-forge cubinlinker ptxcompiler
+
+To install with pip, use the NVIDIA package index:
+
+.. code:: bash
+
+   pip install --extra-index-url https://pypi.nvidia.com ptxcompiler-cu11 cubinlinker-cu11
+
+Enabling MVC Support
+--------------------
+
+MVC support is enabled by setting the environment variable:
+
+.. code:: bash
+
+   export NUMBA_CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY=1
+
+
+or by setting a configuration variable prior to using any CUDA functionality in
+Numba:
+
+.. code:: python
+
+   from numba import config
+   config.CUDA_ENABLE_MINOR_VERSION_COMPATIBILITY = True
+
+
+References
+----------
+
+Further information about Minor Version Compatibility may be found in:
+
+- The `CUDA Compatibility Guide
+  <https://docs.nvidia.com/deploy/cuda-compatibility/index.html>`_.
+- The `README for pynvjitlink
+  <https://github.com/rapidsai/pynvjitlink/blob/main/README.md>`_.
+- The `README for ptxcompiler
+  <https://github.com/rapidsai/ptxcompiler/blob/main/README.md>`_.

--- a/docs/source/user/overview.rst
+++ b/docs/source/user/overview.rst
@@ -1,0 +1,133 @@
+========
+Overview
+========
+
+Numba supports CUDA GPU programming by directly compiling a restricted subset
+of Python code into CUDA kernels and device functions following the CUDA
+execution model.  Kernels written in Numba appear to have direct access
+to NumPy arrays.  NumPy arrays are transferred between the CPU and the
+GPU automatically.
+
+
+Terminology
+===========
+
+Several important terms in the topic of CUDA programming are listed here:
+
+- *host*: the CPU
+- *device*: the GPU
+- *host memory*: the system main memory
+- *device memory*: onboard memory on a GPU card
+- *kernels*: a GPU function launched by the host and executed on the device
+- *device function*: a GPU function executed on the device which can only be
+  called from the device (i.e. from a kernel or another device function)
+
+
+Programming model
+=================
+
+Most CUDA programming facilities exposed by Numba map directly to the CUDA
+C language offered by NVidia.  Therefore, it is recommended you read the
+official `CUDA C programming guide <http://docs.nvidia.com/cuda/cuda-c-programming-guide>`_.
+
+
+Requirements
+============
+
+Supported GPUs
+--------------
+
+Numba supports CUDA-enabled GPUs with Compute Capability 3.5 or greater.
+Support for devices with Compute Capability less than 5.0 is deprecated, and
+will be removed in a future Numba release.
+
+Devices with Compute Capability 5.0 or greater include (but are not limited to):
+
+- Embedded platforms: NVIDIA Jetson Nano, Jetson Orin Nano, TX1, TX2, Xavier
+  NX, AGX Xavier, AGX Orin.
+- Desktop / Server GPUs: All GPUs with Maxwell microarchitecture or later. E.g.
+  GTX 9 / 10 / 16 series, RTX 20 / 30 / 40 series, Quadro / Tesla M / P / V /
+  RTX series, RTX A series, RTX Ada / SFF, A / L series, H100.
+- Laptop GPUs: All GPUs with Maxwell microarchitecture or later. E.g. MX series,
+  Quadro M / P / T series (mobile), RTX 20 / 30 series (mobile), RTX A series
+  (mobile).
+
+Software
+--------
+
+Numba aims to support CUDA Toolkit versions released within the last 3 years.
+Presently 11.2 is the minimum required toolkit version. An NVIDIA driver
+sufficient for the toolkit version is also required (see also
+:ref:`minor-version-compatibility`).
+
+Conda users can install the CUDA Toolkit into a conda environment.
+
+For CUDA 12, ``cuda-nvcc`` and ``cuda-nvrtc`` are required::
+
+    $ conda install -c conda-forge cuda-nvcc cuda-nvrtc "cuda-version>=12.0"
+
+For CUDA 11, ``cudatoolkit`` is required::
+
+    $ conda install -c conda-forge cudatoolkit "cuda-version>=11.2,<12.0"
+
+If you are not using Conda or if you want to use a different version of CUDA
+toolkit, the following describes how Numba searches for a CUDA toolkit
+installation.
+
+.. _cuda-bindings:
+
+CUDA Bindings
+~~~~~~~~~~~~~
+
+Numba supports interacting with the CUDA Driver API via the `NVIDIA CUDA Python
+bindings <https://nvidia.github.io/cuda-python/>`_ and its own ctypes-based
+bindings. Functionality is equivalent between the two bindings. The
+ctypes-based bindings are presently the default, but the NVIDIA bindings will
+be used by default (if they are available in the environment) in a future Numba
+release.
+
+You can install the NVIDIA bindings with::
+
+   $ conda install -c conda-forge cuda-python
+
+if you are using Conda, or::
+
+   $ pip install cuda-python
+
+if you are using pip.
+
+The use of the NVIDIA bindings is enabled by setting the environment variable
+:envvar:`NUMBA_CUDA_USE_NVIDIA_BINDING` to ``"1"``.
+
+.. _cudatoolkit-lookup:
+
+Setting CUDA Installation Path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Numba searches for a CUDA toolkit installation in the following order:
+
+1. Conda installed CUDA Toolkit packages
+2. Environment variable ``CUDA_HOME``, which points to the directory of the
+   installed CUDA toolkit (i.e. ``/home/user/cuda-12``)
+3. System-wide installation at exactly ``/usr/local/cuda`` on Linux platforms.
+   Versioned installation paths (i.e. ``/usr/local/cuda-12.0``) are intentionally
+   ignored.  Users can use ``CUDA_HOME`` to select specific versions.
+
+In addition to the CUDA toolkit libraries, which can be installed by conda into
+an environment or installed system-wide by the `CUDA SDK installer
+<https://developer.nvidia.com/cuda-downloads>`_, the CUDA target in Numba
+also requires an up-to-date NVIDIA graphics driver.  Updated graphics drivers
+are also installed by the CUDA SDK installer, so there is no need to do both.
+If the ``libcuda`` library is in a non-standard location, users can set
+environment variable ``NUMBA_CUDA_DRIVER`` to the file path (not the directory
+path) of the shared library file.
+
+
+Missing CUDA Features
+=====================
+
+Numba does not implement all features of CUDA, yet.  Some missing features
+are listed below:
+
+* dynamic parallelism
+* texture memory

--- a/docs/source/user/random.rst
+++ b/docs/source/user/random.rst
@@ -1,0 +1,90 @@
+
+.. _cuda-random:
+
+Random Number Generation
+========================
+
+Numba provides a random number generation algorithm that can be executed on
+the GPU.  Due to technical issues with how NVIDIA implemented cuRAND, however,
+Numba's GPU random number generator is not based on cuRAND.  Instead, Numba's
+GPU RNG is an implementation of the `xoroshiro128+ algorithm
+<http://xoroshiro.di.unimi.it/>`_. The xoroshiro128+ algorithm has a period of
+``2**128 - 1``, which is shorter than the period of the XORWOW algorithm
+used by default in cuRAND, but xoroshiro128+ still passes the BigCrush tests
+of random number generator quality.
+
+When using any RNG on the GPU, it is important to make sure that each thread
+has its own RNG state, and they have been initialized to produce non-overlapping
+sequences.  The  numba.cuda.random module provides a host function to do this,
+as well as CUDA device functions to obtain uniformly or normally distributed
+random numbers.
+
+.. note:: Numba (like cuRAND) uses the
+    `Box-Muller transform <https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform>`
+    to generate normally distributed random numbers from a uniform generator.
+    However, Box-Muller generates pairs of random numbers, and the current
+    implementation only returns one of them.  As a result, generating normally
+    distributed values is half the speed of uniformly distributed values.
+
+.. automodule:: numba.cuda.random
+    :members: create_xoroshiro128p_states, init_xoroshiro128p_states, xoroshiro128p_uniform_float32, xoroshiro128p_uniform_float64, xoroshiro128p_normal_float32, xoroshiro128p_normal_float64
+    :noindex:
+
+A simple example
+''''''''''''''''
+
+Here is a sample program that uses the random number generator::
+
+    from __future__ import print_function, absolute_import
+
+    from numba import cuda
+    from numba.cuda.random import create_xoroshiro128p_states, xoroshiro128p_uniform_float32
+    import numpy as np
+
+    @cuda.jit
+    def compute_pi(rng_states, iterations, out):
+        """Find the maximum value in values and store in result[0]"""
+        thread_id = cuda.grid(1)
+
+        # Compute pi by drawing random (x, y) points and finding what
+        # fraction lie inside a unit circle
+        inside = 0
+        for i in range(iterations):
+            x = xoroshiro128p_uniform_float32(rng_states, thread_id)
+            y = xoroshiro128p_uniform_float32(rng_states, thread_id)
+            if x**2 + y**2 <= 1.0:
+                inside += 1
+
+        out[thread_id] = 4.0 * inside / iterations
+
+    threads_per_block = 64
+    blocks = 24
+    rng_states = create_xoroshiro128p_states(threads_per_block * blocks, seed=1)
+    out = np.zeros(threads_per_block * blocks, dtype=np.float32)
+
+    compute_pi[blocks, threads_per_block](rng_states, 10000, out)
+    print('pi:', out.mean())
+
+An example of managing RNG state size and using a 3D grid
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+The number of RNG states scales with the number of threads using the RNG, so it
+is often better to use strided loops in conjunction with the RNG in order to
+keep the state size manageable.
+
+In the following example, which initializes a large 3D array with random
+numbers, using one thread per output element would result in 453,617,100 RNG
+states.  This would take a long time to initialize and poorly utilize the GPU.
+Instead, it uses a fixed size 3D grid with a total of 2,097,152 (``(16 ** 3) *
+(8 ** 3)``) threads striding over the output array. The 3D thread indices
+``startx``, ``starty``, and ``startz``  are linearized into a 1D index,
+``tid``, to index into the 2,097,152 RNG states.
+
+
+.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_random.py
+   :language: python
+   :caption: from ``test_ex_3d_grid of ``numba/cuda/tests/doc_example/test_random.py``
+   :start-after: magictoken.ex_3d_grid.begin
+   :end-before: magictoken.ex_3d_grid.end
+   :dedent: 8
+   :linenos:

--- a/docs/source/user/random.rst
+++ b/docs/source/user/random.rst
@@ -81,7 +81,7 @@ Instead, it uses a fixed size 3D grid with a total of 2,097,152 (``(16 ** 3) *
 ``tid``, to index into the 2,097,152 RNG states.
 
 
-.. literalinclude:: ../../../numba/cuda/tests/doc_examples/test_random.py
+.. literalinclude:: ../../../numba_cuda/numba/cuda/tests/doc_examples/test_random.py
    :language: python
    :caption: from ``test_ex_3d_grid of ``numba/cuda/tests/doc_example/test_random.py``
    :start-after: magictoken.ex_3d_grid.begin

--- a/docs/source/user/reduction.rst
+++ b/docs/source/user/reduction.rst
@@ -1,0 +1,33 @@
+GPU Reduction
+==============
+
+Writing a reduction algorithm for CUDA GPU can be tricky.  Numba provides a
+``@reduce`` decorator for converting a simple binary operation into a reduction
+kernel. An example follows::
+
+    import numpy
+    from numba import cuda
+
+    @cuda.reduce
+    def sum_reduce(a, b):
+        return a + b
+
+    A = (numpy.arange(1234, dtype=numpy.float64)) + 1
+    expect = A.sum()      # NumPy sum reduction
+    got = sum_reduce(A)   # cuda sum reduction
+    assert expect == got
+
+Lambda functions can also be used here::
+
+    sum_reduce = cuda.reduce(lambda a, b: a + b)
+
+The Reduce class
+----------------
+
+The ``reduce`` decorator creates an instance of the ``Reduce`` class.
+Currently, ``reduce`` is an alias to ``Reduce``, but this behavior is not
+guaranteed.
+
+.. autoclass:: numba.cuda.Reduce
+   :members: __init__, __call__
+   :member-order: bysource

--- a/docs/source/user/simulator.rst
+++ b/docs/source/user/simulator.rst
@@ -1,0 +1,104 @@
+
+.. _simulator:
+
+=================================================
+Debugging CUDA Python with the the CUDA Simulator
+=================================================
+
+Numba includes a CUDA Simulator that implements most of the semantics in CUDA
+Python using the Python interpreter and some additional Python code. This can
+be used to debug CUDA Python code, either by adding print statements to your
+code, or by using the debugger to step through the execution of an individual
+thread.
+
+The simulator deliberately allows running non-CUDA code like starting a debugger 
+and printing arbitrary expressions for debugging purposes. Therefore, it is
+best to start from code that compiles for the CUDA target, and then move over to
+the simulator to investigate issues.
+
+Execution of kernels is performed by the simulator one block at a time. One
+thread is spawned for each thread in the block, and scheduling of the execution
+of these threads is left up to the operating system.
+
+Using the simulator
+===================
+
+The simulator is enabled by setting the environment variable
+:envvar:`NUMBA_ENABLE_CUDASIM` to 1 prior to importing Numba. CUDA Python code 
+may then be executed as normal. The easiest way to use the debugger inside a
+kernel is to only stop a single thread, otherwise the interaction with the
+debugger is difficult to handle. For example, the kernel below will stop in
+the thread ``<<<(3,0,0), (1, 0, 0)>>>``::
+
+    @cuda.jit
+    def vec_add(A, B, out):
+        x = cuda.threadIdx.x
+        bx = cuda.blockIdx.x
+        bdx = cuda.blockDim.x
+        if x == 1 and bx == 3:
+            from pdb import set_trace; set_trace()
+        i = bx * bdx + x
+        out[i] = A[i] + B[i]
+
+when invoked with a one-dimensional grid and one-dimensional blocks.
+
+Supported features
+==================
+
+The simulator aims to provide as complete a simulation of execution on a real
+GPU as possible - in particular, the following are supported:
+
+* Atomic operations
+* Constant memory
+* Local memory
+* Shared memory: declarations of shared memory arrays must be on separate source
+  lines, since the simulator uses source line information to keep track of
+  allocations of shared memory across threads.
+* Mapped arrays.
+* Host and device memory operations: copying and setting memory.
+* :func:`.syncthreads` is supported - however, in the case where divergent
+  threads enter different :func:`.syncthreads` calls, the launch will not fail,
+  but unexpected behaviour will occur. A future version of the simulator may
+  detect this condition.
+* The stream API is supported, but all operations occur sequentially and
+  synchronously, unlike on a real device. Synchronising on a stream is therefore
+  a no-op.
+* The event API is also supported, but provides no meaningful timing
+  information.
+* Data transfer to and from the GPU - in particular, creating array objects with
+  :func:`.device_array` and :func:`.device_array_like`. The APIs for pinned memory
+  :func:`.pinned` and :func:`.pinned_array` are also supported, but no pinning
+  takes place.
+* The driver API implementation of the list of GPU contexts (``cuda.gpus`` and
+  ``cuda.cudadrv.devices.gpus``) is supported, and reports a single GPU context.
+  This context can be closed and reset as the real one would.
+* The :func:`.detect` function is supported, and reports one device called
+  `SIMULATOR`.
+* Cooperative grids: A cooperative kernel can be launched, but with only one
+  block - the simulator always returns ``1`` from a kernel overload's
+  :meth:`~numba.cuda.dispatcher._Kernel.max_cooperative_grid_blocks` method.
+
+Some limitations of the simulator include:
+
+* It does not perform type checking/type inference. If any argument types to a
+  jitted function are incorrect, or if the specification of the type of any
+  local variables are incorrect, this will not be detected by the simulator.
+* Only one GPU is simulated.
+* Multithreaded accesses to a single GPU are not supported, and will result in
+  unexpected behaviour.
+* Most of the driver API is unimplemented.
+* It is not possible to link PTX code with CUDA Python functions.
+* Warps and warp-level operations are not yet implemented.
+* Because the simulator executes kernels using the Python interpreter,
+  structured array access by attribute that works with the hardware target may
+  fail in the simulator - see :ref:`structured-array-access`.
+* Operations directly against device arrays are only partially supported, that
+  is, testing equality, less than, greater than, and basic mathematical 
+  operations are supported, but many other operations, such as the in-place 
+  operators and bit operators are not.
+* The :func:`ffs() <numba.cuda.ffs>` function only works correctly for values
+  that can be represented using 32-bit integers.
+
+Obviously, the speed of the simulator is also much lower than that of a real
+device. It may be necessary to reduce the size of input data and the size of the
+CUDA grid in order to make debugging with the simulator tractable.

--- a/docs/source/user/ufunc.rst
+++ b/docs/source/user/ufunc.rst
@@ -1,0 +1,140 @@
+CUDA Ufuncs and Generalized Ufuncs
+==================================
+
+This page describes the CUDA ufunc-like object.
+
+To support the programming pattern of CUDA programs, CUDA Vectorize and
+GUVectorize cannot produce a conventional ufunc.  Instead, a ufunc-like
+object is returned.  This object is a close analog but not fully
+compatible with a regular NumPy ufunc.  The CUDA ufunc adds support for
+passing intra-device arrays (already on the GPU device) to reduce
+traffic over the PCI-express bus.  It also accepts a `stream` keyword
+for launching in asynchronous mode.
+
+Example: Basic Example
+------------------------
+
+::
+
+    import math
+    from numba import vectorize, cuda
+    import numpy as np
+
+    @vectorize(['float32(float32, float32, float32)',
+                'float64(float64, float64, float64)'],
+               target='cuda')
+    def cu_discriminant(a, b, c):
+        return math.sqrt(b ** 2 - 4 * a * c)
+
+    N = 10000
+    dtype = np.float32
+
+    # prepare the input
+    A = np.array(np.random.sample(N), dtype=dtype)
+    B = np.array(np.random.sample(N) + 10, dtype=dtype)
+    C = np.array(np.random.sample(N), dtype=dtype)
+
+    D = cu_discriminant(A, B, C)
+
+    print(D)  # print result
+
+Example: Calling Device Functions
+----------------------------------
+
+All CUDA ufunc kernels have the ability to call other CUDA device functions::
+
+    from numba import vectorize, cuda
+
+    # define a device function
+    @cuda.jit('float32(float32, float32, float32)', device=True, inline=True)
+    def cu_device_fn(x, y, z):
+        return x ** y / z
+
+    # define a ufunc that calls our device function
+    @vectorize(['float32(float32, float32, float32)'], target='cuda')
+    def cu_ufunc(x, y, z):
+        return cu_device_fn(x, y, z)
+
+
+Generalized CUDA ufuncs
+-----------------------
+
+Generalized ufuncs may be executed on the GPU using CUDA, analogous to
+the CUDA ufunc functionality.  This may be accomplished as follows::
+
+    from numba import guvectorize
+
+    @guvectorize(['void(float32[:,:], float32[:,:], float32[:,:])'], 
+                 '(m,n),(n,p)->(m,p)', target='cuda')
+    def matmulcore(A, B, C):
+        ...
+
+
+.. comment
+
+    Example: A Chunk at a Time
+    ---------------------------
+
+    Partitioning your data into chunks allows computation and memory transfer
+    to be overlapped.  This can increase the throughput of your ufunc and
+    enables your ufunc to operate on data that is larger than the memory
+    capacity of your GPU.  For example:
+
+    ::
+
+        import math
+        from numba import vectorize, cuda
+        import numpy as np
+
+        # the ufunc kernel
+        def discriminant(a, b, c):
+            return math.sqrt(b ** 2 - 4 * a * c)
+
+        cu_discriminant = vectorize(['float32(float32, float32, float32)',
+                                     'float64(float64, float64, float64)'],
+                                    target='cuda')(discriminant)
+
+        N = int(1e+8)
+        dtype = np.float32
+
+        # prepare the input
+        A = np.array(np.random.sample(N), dtype=dtype)
+        B = np.array(np.random.sample(N) + 10, dtype=dtype)
+        C = np.array(np.random.sample(N), dtype=dtype)
+        D = np.empty(A.shape, dtype=A.dtype)
+
+        # create a CUDA stream
+        stream = cuda.stream()
+
+        chunksize = 1e+6
+        chunkcount = N // chunksize
+
+        # partition NumPy arrays into chunks
+        # no copying is performed
+        sA = np.split(A, chunkcount)
+        sB = np.split(B, chunkcount)
+        sC = np.split(C, chunkcount)
+        sD = np.split(D, chunkcount)
+
+        device_ptrs = []
+
+        with stream.auto_synchronize():
+            # every operation in this context with be launched asynchronously
+            # by using the CUDA stream
+
+            # for each chunk
+            for a, b, c, d in zip(sA, sB, sC, sD):
+                # transfer to device
+                dA = cuda.to_device(a, stream)
+                dB = cuda.to_device(b, stream)
+                dC = cuda.to_device(c, stream)
+                dD = cuda.to_device(d, stream, copy=False) # no copying
+                # launch kernel
+                cu_discriminant(dA, dB, dC, out=dD, stream=stream)
+                # retrieve result
+                dD.copy_to_host(d, stream)
+                # store device pointers to prevent them from freeing before
+                # the kernel is scheduled
+                device_ptrs.extend([dA, dB, dC, dD])
+
+        # data is ready at this point inside D


### PR DESCRIPTION
This adds a copy of the docs and a basic build of them with the NVIDIA theme.

There will be some editing necessary in future to make the docs a more coherent read outside of the context of the main Numba documentation.

No CI build of the docs is added in this PR - it could be added later.